### PR TITLE
Reverted lines to how they are in official develop branch

### DIFF
--- a/crypto/curve.go
+++ b/crypto/curve.go
@@ -33,7 +33,14 @@ type BitCurve struct {
 }
 
 func (BitCurve *BitCurve) Params() *elliptic.CurveParams {
-	return &elliptic.CurveParams{BitCurve.P, BitCurve.N, BitCurve.B, BitCurve.Gx, BitCurve.Gy, BitCurve.BitSize}
+       return &elliptic.CurveParams{
+               P:       BitCurve.P,
+               N:       BitCurve.N,
+               B:       BitCurve.B,
+               Gx:      BitCurve.Gx,
+               Gy:      BitCurve.Gy,
+               BitSize: BitCurve.BitSize,
+       }
 }
 
 // IsOnBitCurve returns true if the given (x,y) lies on the BitCurve.


### PR DESCRIPTION
This fixed the following error when using "make geth":

```
github.com/ethereum/go-ethereum/crypto
# github.com/ethereum/go-ethereum/crypto
crypto/curve.go:36: too few values in struct initializer
Makefile:9: recipe for target 'geth' failed
make: *** [geth] Error 2
```
