### PR TITLE
core, les: implement general atomic db

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1570,7 +1570,7 @@ func RegisterEthService(stack *node.Node, cfg *eth.Config) {
 		err = stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
 			fullNode, err := eth.New(ctx, cfg)
 			if fullNode != nil && cfg.LightServ > 0 {
-				ls, _ := les.NewLesServer(fullNode, cfg)
+				ls, _ := les.NewLesServer(ctx, fullNode, cfg)
 				fullNode.AddLesServer(ls)
 			}
 			return fullNode, err

--- a/core/rawdb/atomic_database.go
+++ b/core/rawdb/atomic_database.go
@@ -1,0 +1,201 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rawdb
+
+import (
+	"sync"
+
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+// AtomicDatabase is a wrapper of underlying ethdb.Dababase but offers more
+// additional atomicity guarantee.
+//
+// The typical usage of atomic database is: the db handler is used by different
+// modules but atomicity guarantee is required when update some data across the
+// modules. In this case, call `OpenTransaction` to switch db to atomic mode, do
+// whatever operation needed and call `CloseTransaction` to commit the change.
+type AtomicDatabase struct {
+	db    ethdb.Database
+	lock  sync.Mutex
+	batch ethdb.Batch // It's not thread safe!!
+}
+
+func NewAtomicDatabase(db ethdb.Database) ethdb.Database {
+	return &AtomicDatabase{db: db}
+}
+
+// OpenTransaction creates an underlying batch to contain all
+// following changes. Commit the previous batch if it's not nil.
+func (db *AtomicDatabase) OpenTransaction() {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	if db.batch != nil {
+		db.batch.Write()
+	}
+	db.batch = db.db.NewBatch()
+}
+
+// DropTransaction drops the previous batch. Normally used when
+// database updating is reverted.
+func (db *AtomicDatabase) DropTransaction() {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	db.batch = nil
+}
+
+// CloseTransaction commits all changes in the current batch and
+// finishes the atomic db updating.
+func (db *AtomicDatabase) CloseTransaction() {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	if db.batch == nil {
+		return
+	}
+	db.batch.Write()
+	db.batch = nil
+}
+
+// Close implements the Database interface and closes the underlying database.
+func (db *AtomicDatabase) Close() error {
+	return db.db.Close()
+}
+
+// Has is a noop passthrough that just forwards the request to the underlying
+// database.
+func (db *AtomicDatabase) Has(key []byte) (bool, error) {
+	return db.db.Has(key)
+}
+
+// Get is a noop passthrough that just forwards the request to the underlying
+// database.
+func (db *AtomicDatabase) Get(key []byte) ([]byte, error) {
+	return db.db.Get(key)
+}
+
+// HasAncient is a noop passthrough that just forwards the request to the underlying
+// database.
+func (db *AtomicDatabase) HasAncient(kind string, number uint64) (bool, error) {
+	return db.db.HasAncient(kind, number)
+}
+
+// Ancient is a noop passthrough that just forwards the request to the underlying
+// database.
+func (db *AtomicDatabase) Ancient(kind string, number uint64) ([]byte, error) {
+	return db.db.Ancient(kind, number)
+}
+
+// Ancients is a noop passthrough that just forwards the request to the underlying
+// database.
+func (db *AtomicDatabase) Ancients() (uint64, error) {
+	return db.db.Ancients()
+}
+
+// AncientSize is a noop passthrough that just forwards the request to the underlying
+// database.
+func (db *AtomicDatabase) AncientSize(kind string) (uint64, error) {
+	return db.db.AncientSize(kind)
+}
+
+// AppendAncient is a noop passthrough that just forwards the request to the underlying
+// database.
+func (db *AtomicDatabase) AppendAncient(number uint64, hash, header, body, receipts, td []byte) error {
+	return db.db.AppendAncient(number, hash, header, body, receipts, td)
+}
+
+// TruncateAncients is a noop passthrough that just forwards the request to the underlying
+// database.
+func (db *AtomicDatabase) TruncateAncients(items uint64) error {
+	return db.db.TruncateAncients(items)
+}
+
+// Sync is a noop passthrough that just forwards the request to the underlying
+// database.
+func (db *AtomicDatabase) Sync() error {
+	return db.db.Sync()
+}
+
+// Put inserts the given value into the database. If the transaction
+// is opened, put the value in batch, otherwise just forwards the
+// request to the underlying database.
+func (db *AtomicDatabase) Put(key []byte, value []byte) error {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	if db.batch != nil {
+		return db.batch.Put(key, value)
+	}
+	return db.db.Put(key, value)
+}
+
+// Delete removes the specified entry from the database. If the transaction
+// is opened, put the deletion in batch, otherwise just forwards the request
+// to the underlying database.
+func (db *AtomicDatabase) Delete(key []byte) error {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	if db.batch != nil {
+		return db.batch.Delete(key)
+	}
+	return db.db.Delete(key)
+}
+
+// NewIterator creates a binary-alphabetical iterator over the entire keyspace
+// contained within the database.
+func (db *AtomicDatabase) NewIterator() ethdb.Iterator {
+	return db.NewIteratorWithPrefix(nil)
+}
+
+// NewIteratorWithStart creates a binary-alphabetical iterator over a subset of
+// database content starting at a particular initial key (or after, if it does
+// not exist).
+func (db *AtomicDatabase) NewIteratorWithStart(start []byte) ethdb.Iterator {
+	return db.db.NewIteratorWithStart(start)
+}
+
+// NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
+// of database content with a particular key prefix.
+func (db *AtomicDatabase) NewIteratorWithPrefix(prefix []byte) ethdb.Iterator {
+	return db.db.NewIteratorWithPrefix(prefix)
+}
+
+// Stat returns a particular internal stat of the database.
+func (db *AtomicDatabase) Stat(property string) (string, error) {
+	return db.db.Stat(property)
+}
+
+// Compact flattens the underlying data store for the given key range. In essence,
+// deleted and overwritten versions are discarded, and the data is rearranged to
+// reduce the cost of operations needed to access them.
+//
+// A nil start is treated as a key before all keys in the data store; a nil limit
+// is treated as a key after all keys in the data store. If both is nil then it
+// will compact entire data store.
+func (db *AtomicDatabase) Compact(start []byte, limit []byte) error {
+	return db.db.Compact(start, limit)
+}
+
+// NewBatch creates a write-only database that buffers changes to its host db
+// until a final write is called, each operation prefixing all keys with the
+// pre-configured string.
+func (db *AtomicDatabase) NewBatch() ethdb.Batch {
+	return db.db.NewBatch()
+}

--- a/les/api_test.go
+++ b/les/api_test.go
@@ -508,7 +508,7 @@ func newLesServerService(ctx *adapters.ServiceContext) (node.Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	server, err := NewLesServer(ethereum, &config)
+	server, err := NewLesServer(ctx.NodeContext, ethereum, &config)
 	if err != nil {
 		return nil, err
 	}

--- a/les/server.go
+++ b/les/server.go
@@ -20,6 +20,8 @@ import (
 	"crypto/ecdsa"
 	"time"
 
+	"github.com/ethereum/go-ethereum/core/rawdb"
+
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common/mclock"
 	"github.com/ethereum/go-ethereum/core"
@@ -134,9 +136,9 @@ func NewLesServer(ctx *node.ServiceContext, e *eth.Ethereum, config *eth.Config)
 	if err != nil {
 		return nil, err
 	}
-	srv.incentiveDB = incentiveDB
+	srv.incentiveDB = rawdb.NewAtomicDatabase(incentiveDB)
 
-	srv.clientPool = newClientPool(incentiveDB, srv.minCapacity, srv.freeCapacity, mclock.System{}, func(id enode.ID) { go srv.peers.disconnect(peerIdToString(id)) })
+	srv.clientPool = newClientPool(srv.incentiveDB, srv.minCapacity, srv.freeCapacity, mclock.System{}, func(id enode.ID) { go srv.peers.disconnect(peerIdToString(id)) })
 	srv.clientPool.setDefaultFactors(priceFactors{0, 1, 1}, priceFactors{0, 1, 1})
 	srv.tokenSale = newTokenSale(srv.clientPool, 0.1, 100)
 	if config.LespayTestModule {

--- a/les/server.go
+++ b/les/server.go
@@ -20,11 +20,10 @@ import (
 	"crypto/ecdsa"
 	"time"
 
-	"github.com/ethereum/go-ethereum/core/rawdb"
-
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common/mclock"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/les/checkpointoracle"

--- a/les/tokensale.go
+++ b/les/tokensale.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/mclock"
-	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rlp"
 )
@@ -41,8 +40,8 @@ const (
 // payment technologies
 type paymentReceiver interface {
 	info() keyValueList
-	receivePayment(from enode.ID, proofOfPayment []byte, reader ethdb.KeyValueReader, writer ethdb.KeyValueWriter) (value uint64, err error)
-	requestPayment(from enode.ID, value uint64, reader ethdb.KeyValueReader) uint64
+	receivePayment(from enode.ID, proofOfPayment []byte) (value uint64, err error)
+	requestPayment(from enode.ID, value uint64) uint64
 }
 
 // tokenSale handles client balance deposits, conversion to and from service tokens
@@ -438,7 +437,7 @@ func (t *tokenSale) connection(id enode.ID, freeID string, requestedCapacity uin
 		if rec, ok := t.receivers[recID]; !ok || pcMissing == math.MaxUint64 {
 			paymentRequired[i] = math.MaxUint64
 		} else {
-			paymentRequired[i] = rec.requestPayment(id, pcMissing, newReaderTable(t.clientPool.ndb.db, receiverPrefix(id, recID)))
+			paymentRequired[i] = rec.requestPayment(id, pcMissing)
 		}
 	}
 	return
@@ -446,12 +445,10 @@ func (t *tokenSale) connection(id enode.ID, freeID string, requestedCapacity uin
 
 // deposit credits a payment on the sender's account using the specified payment module
 func (t *tokenSale) deposit(id enode.ID, paymentModule string, proofOfPayment []byte) (pcValue, pcBalance uint64, err error) {
-	writer := t.clientPool.ndb.atomicWriteLock(id.Bytes())
 	t.lock.Lock()
-	defer func() {
-		t.lock.Unlock()
-		t.clientPool.ndb.atomicWriteUnlock(id.Bytes())
-	}()
+	defer t.lock.Unlock()
+	t.clientPool.ndb.openTransaction()
+	defer t.clientPool.ndb.closeTransaction()
 
 	cb := t.clientPool.ndb.getCurrencyBalance(id)
 	pcBalance = cb.amount
@@ -459,8 +456,7 @@ func (t *tokenSale) deposit(id enode.ID, paymentModule string, proofOfPayment []
 	if pm == nil {
 		return 0, pcBalance, fmt.Errorf("Unknown payment receiver '%s'", paymentModule)
 	}
-	prefix := receiverPrefix(id, paymentModule)
-	pcValue, err = pm.receivePayment(id, proofOfPayment, newReaderTable(t.clientPool.ndb.db, prefix), newWriterTable(writer, prefix))
+	pcValue, err = pm.receivePayment(id, proofOfPayment)
 	if err != nil {
 		return 0, pcBalance, err
 	}
@@ -484,12 +480,10 @@ func (t *tokenSale) deposit(id enode.ID, paymentModule string, proofOfPayment []
 // is impossible to do a conversion twice. In exchange the sender needs to know its current
 // balances (which it probably does if it has made a previous call to just ask the current price).
 func (t *tokenSale) buyTokens(id enode.ID, maxSpend, minReceive uint64, relative, spendAll bool) (pcBalance, tokenBalance, spend, receive uint64, success bool) {
-	t.clientPool.ndb.atomicWriteLock(id.Bytes())
 	t.lock.Lock()
-	defer func() {
-		t.lock.Unlock()
-		t.clientPool.ndb.atomicWriteUnlock(id.Bytes())
-	}()
+	defer t.lock.Unlock()
+	t.clientPool.ndb.openTransaction()
+	defer t.clientPool.ndb.closeTransaction()
 
 	pb := t.clientPool.getPosBalance(id)
 	tokenBalance = pb.value.value(t.clientPool.posExpiration(mclock.Now()))
@@ -537,12 +531,10 @@ func (t *tokenSale) buyTokens(id enode.ID, maxSpend, minReceive uint64, relative
 // sellTokens tries to convert service tokens to permanent balance (nominated in the server's
 // preferred currency, PC). Parameters work similarly to buyTokens.
 func (t *tokenSale) sellTokens(id enode.ID, maxSell, minRefund uint64, relative, sellAll bool) (pcBalance, tokenBalance, sell, refund uint64, success bool) {
-	t.clientPool.ndb.atomicWriteLock(id.Bytes())
 	t.lock.Lock()
-	defer func() {
-		t.lock.Unlock()
-		t.clientPool.ndb.atomicWriteUnlock(id.Bytes())
-	}()
+	defer t.lock.Unlock()
+	t.clientPool.ndb.openTransaction()
+	defer t.clientPool.ndb.closeTransaction()
 
 	pb := t.clientPool.getPosBalance(id)
 	tokenBalance = pb.value.value(t.clientPool.posExpiration(mclock.Now()))
@@ -792,7 +784,7 @@ func (t testReceiver) info() keyValueList {
 
 // receivePayment implements paymentReceiver. proofOfPayment is a base 10 ascii number
 // which is credited to the sender's account without any further conditions.
-func (t testReceiver) receivePayment(from enode.ID, proofOfPayment []byte, reader ethdb.KeyValueReader, writer ethdb.KeyValueWriter) (value uint64, err error) {
+func (t testReceiver) receivePayment(from enode.ID, proofOfPayment []byte) (value uint64, err error) {
 	if len(proofOfPayment) > 8 {
 		err = fmt.Errorf("proof of payment is too long; max 8 bytes long big endian integer expected")
 		return
@@ -804,57 +796,6 @@ func (t testReceiver) receivePayment(from enode.ID, proofOfPayment []byte, reade
 }
 
 // requestPayment implements paymentReceiver
-func (t testReceiver) requestPayment(from enode.ID, value uint64, reader ethdb.KeyValueReader) uint64 {
+func (t testReceiver) requestPayment(from enode.ID, value uint64) uint64 {
 	return value
-}
-
-// readerTable is a wrapper around a database that prefixes each key access with a pre-
-// configured string.
-type readerTable struct {
-	db     ethdb.KeyValueReader
-	prefix []byte
-}
-
-// newReaderTable returns a database object that prefixes all keys with a given string.
-func newReaderTable(db ethdb.KeyValueReader, prefix []byte) ethdb.KeyValueReader {
-	return &readerTable{
-		db:     db,
-		prefix: prefix,
-	}
-}
-
-// Has retrieves if a prefixed version of a key is present in the database.
-func (t *readerTable) Has(key []byte) (bool, error) {
-	return t.db.Has(append(t.prefix, key...))
-}
-
-// Get retrieves the given prefixed key if it's present in the database.
-func (t *readerTable) Get(key []byte) ([]byte, error) {
-	return t.db.Get(append(t.prefix, key...))
-}
-
-// writerTable is a wrapper around a database that prefixes each key access with a pre-
-// configured string.
-type writerTable struct {
-	db     ethdb.KeyValueWriter
-	prefix []byte
-}
-
-// newReaderTable returns a database object that prefixes all keys with a given string.
-func newWriterTable(db ethdb.KeyValueWriter, prefix []byte) ethdb.KeyValueWriter {
-	return &writerTable{
-		db:     db,
-		prefix: prefix,
-	}
-}
-
-// Put inserts the given value into the database at a prefixed version of the
-// provided key.
-func (t *writerTable) Put(key []byte, value []byte) error {
-	return t.db.Put(append(t.prefix, key...), value)
-}
-
-// Delete removes the given prefixed key from the database.
-func (t writerTable) Delete(key []byte) error {
-	return t.db.Delete(append(t.prefix, key...))
 }


### PR DESCRIPTION
This PR introduces an atomic database implementation. I still keep the original format, but add some additional fix to it.

The reason I don't choose your child database idea is: in practice we will only assign a single db handler for each module which needs to maintain data.  If we use the `child database` idea or your original idea by passing a reader and writer, **it will break the code in another module**. Another module sometimes needs to use the externally given handler, sometimes use its own db handler.

For example, if we update some data in `token sale` module and we pass a handler(rw) to payment module, we will ask the payment module to write data by using the given handler to ensure the atomicity.

However, payment module also have its own db APIs defined. And also we still need to read/write some data in payment module by its own db handler like: `payment sender creates lottery, issues new cheques, etc`.

So my general idea is: we only define a single db `atomic database` and pass it to each module.
In the atomic data we apply the magic. If we need to put data atomically, call `openTransaction`.

Regrading your concerns: `The problem is that the atomicity is required for each client separately while the data belonging to different clients might be accessed simultaneously.` It's true we can only guarantee the atomicity for all write operations, but for each client. But it's okay. We might accumulate lots of data in the batch, make it big. But as long as the atomicity is not required all the time, we can find a timing to flush them out.

And regarding the performance, it needs a lock to protect batch, but I think it's okay. We don't have too much performance requirement for incentive data updating. Correctness is the most important thing.

