### PR TITLE
les/lespay: twist timestats

### DIFF
--- a/les/lespay/client/requestbasket_test.go
+++ b/les/lespay/client/requestbasket_test.go
@@ -81,7 +81,7 @@ func TestConvertMapping(t *testing.T) {
 func TestReqValueFactor(t *testing.T) {
 	var ref referenceBasket
 	ref.refBasket = make(requestBasket, 4)
-	for i, _ := range ref.refBasket {
+	for i := range ref.refBasket {
 		ref.refBasket[i].amount = uint64(i+1) * referenceFactor
 		ref.refBasket[i].value = uint64(i+1) * referenceFactor
 	}
@@ -99,7 +99,7 @@ func TestReqValueAdjustment(t *testing.T) {
 	cost2 := []uint64{100000, 200000, 300000}
 	var ref referenceBasket
 	ref.refBasket = make(requestBasket, 3)
-	for i, _ := range ref.refBasket {
+	for i := range ref.refBasket {
 		ref.refBasket[i].amount = 123 * referenceFactor
 		ref.refBasket[i].value = 123 * referenceFactor
 	}

--- a/les/lespay/client/valuetracker.go
+++ b/les/lespay/client/valuetracker.go
@@ -44,7 +44,7 @@ var (
 type NodeValueTracker struct {
 	lock sync.Mutex
 
-	rtStats, lastRtStats ResponseTimeStats
+	rtStats, lastRtStats TimeStats
 	lastTransfer         mclock.AbsTime
 	basket               serverBasket
 	reqCosts             []uint64
@@ -86,7 +86,7 @@ func (nv *NodeValueTracker) TotalReqValue(expRT time.Duration) float64 {
 	return tv
 }
 
-func (nv *NodeValueTracker) RtStats() ResponseTimeStats {
+func (nv *NodeValueTracker) RtStats() TimeStats {
 	nv.lock.Lock()
 	defer nv.lock.Unlock()
 
@@ -102,7 +102,7 @@ func (nv *NodeValueTracker) updateCosts(reqCosts []uint64, reqValues *[]float64,
 	nv.basket.updateRvFactor(rvFactor)
 }
 
-func (nv *NodeValueTracker) transferStats(now mclock.AbsTime, transferRate, statsExpRate float64) (requestBasket, ResponseTimeStats) {
+func (nv *NodeValueTracker) transferStats(now mclock.AbsTime, transferRate, statsExpRate float64) (requestBasket, TimeStats) {
 	nv.lock.Lock()
 	defer nv.lock.Unlock()
 
@@ -135,7 +135,7 @@ type ValueTracker struct {
 	mappings       [][]string
 	currentMapping int
 	initRefBasket  requestBasket
-	rtStats        ResponseTimeStats
+	rtStats        TimeStats
 
 	transferRate, statsExpRate float64
 }
@@ -147,7 +147,7 @@ type valueTrackerEncV1 struct {
 }
 
 type nodeValueTrackerEncV1 struct {
-	RtStats            ResponseTimeStats
+	RtStats            TimeStats
 	ValueBasketMapping uint
 	ValueBasket        requestBasket
 }
@@ -402,7 +402,7 @@ func (vt *ValueTracker) UpdateCosts(nv *NodeValueTracker, reqCosts []uint64) {
 	nv.updateCosts(reqCosts, &vt.refBasket.reqValues, vt.refBasket.reqValueFactor(reqCosts))
 }
 
-func (vt *ValueTracker) RtStats() ResponseTimeStats {
+func (vt *ValueTracker) RtStats() TimeStats {
 	vt.lock.Lock()
 	defer vt.lock.Unlock()
 

--- a/les/lespay/client/valuetracker_test.go
+++ b/les/lespay/client/valuetracker_test.go
@@ -41,7 +41,7 @@ func TestValueTracker(t *testing.T) {
 	requestList := make([]RequestInfo, testReqTypes)
 	relPrices := make([]float64, testReqTypes)
 	totalAmount := make([]uint64, testReqTypes)
-	for i, _ := range requestList {
+	for i := range requestList {
 		requestList[i] = RequestInfo{Name: "testreq" + strconv.Itoa(i), InitAmount: 1, InitValue: 1}
 		totalAmount[i] = 1
 		relPrices[i] = rand.Float64() + 0.1
@@ -59,12 +59,12 @@ func TestValueTracker(t *testing.T) {
 		updateCosts := func(i int) {
 			costList := make([]uint64, testReqTypes)
 			baseCost := rand.Float64()*10000000 + 100000
-			for j, _ := range costList {
+			for j := range costList {
 				costList[j] = uint64(baseCost * relPrices[j])
 			}
 			vt.UpdateCosts(nodes[i], costList)
 		}
-		for i, _ := range nodes {
+		for i := range nodes {
 			nodes[i] = vt.Register(enode.ID{byte(i)})
 			updateCosts(i)
 		}


### PR DESCRIPTION
This PR twists a little bit `timeStats`. However I still have a few questions not included

- [ ] `The value` is not correct. It should be calculated by `totalValue/totalWeight`
- [ ] `Value` is quite confusing. Basically the lower value returned, it means the average response time is lower. Perhaps we should call it `Score` or something else.
- [ ] Comments should be added