### PR TITLE
les: twist nodestate

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1592,7 +1592,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 // setDNSDiscoveryDefaults configures DNS discovery with the given URL if
 // no URLs are set.
 func setDNSDiscoveryDefaults(cfg *eth.Config, url string) {
-	if cfg.DiscoveryURLs != nil {
+	if len(cfg.DiscoveryURLs) != 0 {
 		return
 	}
 	cfg.DiscoveryURLs = []string{url}

--- a/core/forkid/forkid.go
+++ b/core/forkid/forkid.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 )
@@ -44,6 +44,18 @@ var (
 	ErrLocalIncompatibleOrStale = errors.New("local incompatible or needs update")
 )
 
+// Blockchain defines all necessary method to build a forkID.
+type Blockchain interface {
+	// Config retrieves the chain's fork configuration.
+	Config() *params.ChainConfig
+
+	// Genesis retrieves the chain's genesis block.
+	Genesis() *types.Block
+
+	// CurrentHeader retrieves the current head header of the canonical chain.
+	CurrentHeader() *types.Header
+}
+
 // ID is a fork identifier as defined by EIP-2124.
 type ID struct {
 	Hash [4]byte // CRC32 checksum of the genesis block and passed fork block numbers
@@ -54,7 +66,7 @@ type ID struct {
 type Filter func(id ID) error
 
 // NewID calculates the Ethereum fork ID from the chain config and head.
-func NewID(chain *core.BlockChain) ID {
+func NewID(chain Blockchain) ID {
 	return newID(
 		chain.Config(),
 		chain.Genesis().Hash(),
@@ -85,7 +97,7 @@ func newID(config *params.ChainConfig, genesis common.Hash, head uint64) ID {
 
 // NewFilter creates a filter that returns if a fork ID should be rejected or not
 // based on the local chain's status.
-func NewFilter(chain *core.BlockChain) Filter {
+func NewFilter(chain Blockchain) Filter {
 	return newFilter(
 		chain.Config(),
 		chain.Genesis().Hash(),

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -72,7 +72,7 @@ type Ethereum struct {
 	blockchain      *core.BlockChain
 	protocolManager *ProtocolManager
 	lesServer       LesServer
-	dialCandiates   enode.Iterator
+	dialCandidates  enode.Iterator
 
 	// DB interfaces
 	chainDb ethdb.Database // Block chain database
@@ -222,7 +222,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	}
 	eth.APIBackend.gpo = gasprice.NewOracle(eth.APIBackend, gpoParams)
 
-	eth.dialCandiates, err = eth.setupDiscovery(&ctx.Config.P2P)
+	eth.dialCandidates, err = eth.setupDiscovery(&ctx.Config.P2P)
 	if err != nil {
 		return nil, err
 	}
@@ -519,7 +519,7 @@ func (s *Ethereum) Protocols() []p2p.Protocol {
 	for i, vsn := range ProtocolVersions {
 		protos[i] = s.protocolManager.makeProtocol(vsn)
 		protos[i].Attributes = []enr.Entry{s.currentEthEntry()}
-		protos[i].DialCandidates = s.dialCandiates
+		protos[i].DialCandidates = s.dialCandidates
 	}
 	if s.lesServer != nil {
 		protos = append(protos, s.lesServer.Protocols()...)

--- a/eth/discovery.go
+++ b/eth/discovery.go
@@ -25,9 +25,9 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
-// ethEntry is the "eth" ENR entry which advertises eth protocol
+// EthEntry is the "eth" ENR entry which advertises eth protocol
 // on the discovery network.
-type ethEntry struct {
+type EthEntry struct {
 	ForkID forkid.ID // Fork identifier per EIP-2124
 
 	// Ignore additional fields (for forward compatibility).
@@ -35,7 +35,7 @@ type ethEntry struct {
 }
 
 // ENRKey implements enr.Entry.
-func (e ethEntry) ENRKey() string {
+func (e EthEntry) ENRKey() string {
 	return "eth"
 }
 
@@ -59,8 +59,8 @@ func (eth *Ethereum) startEthEntryUpdate(ln *enode.LocalNode) {
 	}()
 }
 
-func (eth *Ethereum) currentEthEntry() *ethEntry {
-	return &ethEntry{ForkID: forkid.NewID(eth.blockchain)}
+func (eth *Ethereum) currentEthEntry() *EthEntry {
+	return &EthEntry{ForkID: forkid.NewID(eth.blockchain)}
 }
 
 // setupDiscovery creates the node discovery source for the eth protocol.

--- a/les/client.go
+++ b/les/client.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/bloombits"
+	"github.com/ethereum/go-ethereum/core/forkid"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth"
@@ -39,6 +40,7 @@ import (
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/les/checkpointoracle"
 	lpc "github.com/ethereum/go-ethereum/les/lespay/client"
+	"github.com/ethereum/go-ethereum/les/utils"
 	"github.com/ethereum/go-ethereum/light"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
@@ -51,16 +53,18 @@ import (
 type LightEthereum struct {
 	lesCommons
 
-	peers        *serverPeerSet
-	reqDist      *requestDistributor
-	retriever    *retrieveManager
-	odr          *LesOdr
-	relay        *lesTxRelay
-	handler      *clientHandler
-	txPool       *light.TxPool
-	blockchain   *light.LightChain
-	serverPool   *serverPool
-	valueTracker *lpc.ValueTracker
+	peers          *serverPeerSet
+	reqDist        *requestDistributor
+	retriever      *retrieveManager
+	odr            *LesOdr
+	relay          *lesTxRelay
+	handler        *clientHandler
+	txPool         *light.TxPool
+	blockchain     *light.LightChain
+	ns             *utils.NodeStateMachine
+	serverPool     *serverPool
+	valueTracker   *lpc.ValueTracker
+	dialCandidates enode.Iterator
 
 	bloomRequests chan chan *bloombits.Retrieval // Channel receiving bloom data retrieval requests
 	bloomIndexer  *core.ChainIndexer             // Bloom indexer operating during block imports
@@ -105,11 +109,10 @@ func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 		engine:         eth.CreateConsensusEngine(ctx, chainConfig, &config.Ethash, nil, false, chainDb),
 		bloomRequests:  make(chan chan *bloombits.Retrieval),
 		bloomIndexer:   eth.NewBloomIndexer(chainDb, params.BloomBitsBlocksClient, params.HelperTrieConfirmations),
-		serverPool:     newServerPool(chainDb, config.UltraLightServers),
 		valueTracker:   lpc.NewValueTracker(lespayDb, &mclock.System{}, requestList, time.Minute, 1/float64(time.Hour), 1/float64(time.Hour*100), 1/float64(time.Hour*1000)),
 	}
 	peers.subscribe((*vtSubscription)(leth.valueTracker))
-	leth.retriever = newRetrieveManager(peers, leth.reqDist, leth.serverPool)
+	leth.retriever = newRetrieveManager(peers, leth.reqDist)
 	leth.relay = newLesTxRelay(peers, leth.retriever)
 
 	leth.odr = NewLesOdr(chainDb, light.DefaultClientIndexerConfig, leth.retriever)
@@ -141,11 +144,6 @@ func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 	leth.chtIndexer.Start(leth.blockchain)
 	leth.bloomIndexer.Start(leth.blockchain)
 
-	leth.handler = newClientHandler(config.UltraLightServers, config.UltraLightFraction, checkpoint, leth)
-	if leth.handler.ulc != nil {
-		log.Warn("Ultra light client is enabled", "trustedNodes", len(leth.handler.ulc.keys), "minTrustedFraction", leth.handler.ulc.fraction)
-		leth.blockchain.DisableCheckFreq()
-	}
 	// Rewind the chain in case of an incompatible config upgrade.
 	if compat, ok := genesisErr.(*params.ConfigCompatError); ok {
 		log.Warn("Rewinding chain to upgrade configuration", "err", compat)
@@ -160,6 +158,28 @@ func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 	}
 	leth.ApiBackend.gpo = gasprice.NewOracle(leth.ApiBackend, gpoParams)
 
+	dnsdisc, err := leth.setupDiscovery(&ctx.Config.P2P)
+	if err != nil {
+		return nil, err
+	}
+	forkFilter := forkid.NewFilter(leth.blockchain)
+	dnsFiltered := enode.Filter(dnsdisc, func(node *enode.Node) bool {
+		enr := node.Record()
+		ethEntry := &eth.EthEntry{}
+		enr.Load(ethEntry)
+		return forkFilter(ethEntry.ForkID) == nil && enr.Load(&lesEntry{}) == nil
+	})
+	leth.ns = utils.NewNodeStateMachine(lespayDb, []byte("serverpool:"), &mclock.System{})
+	leth.serverPool = newServerPool(leth.ns, leth.valueTracker, dnsFiltered, &mclock.System{}, config.UltraLightServers, false)
+	peers.subscribe(leth.serverPool)
+	leth.dialCandidates = leth.serverPool.dialIterator
+	leth.retriever.setTimeoutCallback(leth.serverPool.getTimeout)
+
+	leth.handler = newClientHandler(config.UltraLightServers, config.UltraLightFraction, checkpoint, leth)
+	if leth.handler.ulc != nil {
+		log.Warn("Ultra light client is enabled", "trustedNodes", len(leth.handler.ulc.keys), "minTrustedFraction", leth.handler.ulc.fraction)
+		leth.blockchain.DisableCheckFreq()
+	}
 	return leth, nil
 }
 
@@ -261,7 +281,7 @@ func (s *LightEthereum) Protocols() []p2p.Protocol {
 			return p.Info()
 		}
 		return nil
-	})
+	}, s.dialCandidates)
 }
 
 // Start implements node.Service, starting all internal goroutines needed by the
@@ -269,15 +289,13 @@ func (s *LightEthereum) Protocols() []p2p.Protocol {
 func (s *LightEthereum) Start(srvr *p2p.Server) error {
 	log.Warn("Light client mode is an experimental feature")
 
+	s.ns.Start() // start before subscribers
+	s.serverPool.start()
 	// Start bloom request workers.
 	s.wg.Add(bloomServiceThreads)
 	s.startBloomHandlers(params.BloomBitsBlocksClient)
 
 	s.netRPCService = ethapi.NewPublicNetAPI(srvr, s.config.NetworkId)
-
-	// clients are searching for the first advertised protocol in the list
-	protocolVersion := AdvertiseProtocolVersions[0]
-	s.serverPool.start(srvr, lesTopic(s.blockchain.Genesis().Hash(), protocolVersion))
 	return nil
 }
 
@@ -285,6 +303,7 @@ func (s *LightEthereum) Start(srvr *p2p.Server) error {
 // Ethereum protocol.
 func (s *LightEthereum) Stop() error {
 	close(s.closeCh)
+	s.ns.Stop() // stop before subscribers
 	s.peers.close()
 	s.reqDist.close()
 	s.odr.Stop()

--- a/les/client_handler.go
+++ b/les/client_handler.go
@@ -64,7 +64,7 @@ func newClientHandler(ulcServers []string, ulcFraction int, checkpoint *params.T
 	if checkpoint != nil {
 		height = (checkpoint.SectionIndex+1)*params.CHTFrequency - 1
 	}
-	handler.fetcher = newLightFetcher(handler)
+	handler.fetcher = newLightFetcher(handler, backend.serverPool.getTimeout)
 	handler.downloader = downloader.New(height, backend.chainDb, nil, backend.eventMux, nil, backend.blockchain, handler.removePeer)
 	handler.backend.peers.subscribe((*downloaderPeerNotify)(handler))
 	return handler
@@ -85,14 +85,9 @@ func (h *clientHandler) runPeer(version uint, p *p2p.Peer, rw p2p.MsgReadWriter)
 	}
 	peer := newServerPeer(int(version), h.backend.config.NetworkId, trusted, p, newMeteredMsgWriter(rw, int(version)))
 	defer peer.close()
-	peer.poolEntry = h.backend.serverPool.connect(peer, peer.Node())
-	if peer.poolEntry == nil {
-		return p2p.DiscRequested
-	}
 	h.wg.Add(1)
 	defer h.wg.Done()
 	err := h.handle(peer)
-	h.backend.serverPool.disconnect(peer.poolEntry)
 	return err
 }
 
@@ -129,10 +124,6 @@ func (h *clientHandler) handle(p *serverPeer) error {
 
 	h.fetcher.announce(p, &announceData{Hash: p.headInfo.Hash, Number: p.headInfo.Number, Td: p.headInfo.Td})
 
-	// pool entry can be nil during the unit test.
-	if p.poolEntry != nil {
-		h.backend.serverPool.registered(p.poolEntry)
-	}
 	// Mark the peer starts to be served.
 	atomic.StoreUint32(&p.serving, 1)
 	defer atomic.StoreUint32(&p.serving, 0)

--- a/les/commons.go
+++ b/les/commons.go
@@ -81,7 +81,7 @@ type NodeInfo struct {
 }
 
 // makeProtocols creates protocol descriptors for the given LES versions.
-func (c *lesCommons) makeProtocols(versions []uint, runPeer func(version uint, p *p2p.Peer, rw p2p.MsgReadWriter) error, peerInfo func(id enode.ID) interface{}) []p2p.Protocol {
+func (c *lesCommons) makeProtocols(versions []uint, runPeer func(version uint, p *p2p.Peer, rw p2p.MsgReadWriter) error, peerInfo func(id enode.ID) interface{}, dialCandidates enode.Iterator) []p2p.Protocol {
 	protos := make([]p2p.Protocol, len(versions))
 	for i, version := range versions {
 		version := version
@@ -93,7 +93,8 @@ func (c *lesCommons) makeProtocols(versions []uint, runPeer func(version uint, p
 			Run: func(peer *p2p.Peer, rw p2p.MsgReadWriter) error {
 				return runPeer(version, peer, rw)
 			},
-			PeerInfo: peerInfo,
+			PeerInfo:       peerInfo,
+			DialCandidates: dialCandidates,
 		}
 	}
 	return protos

--- a/les/distributor.go
+++ b/les/distributor.go
@@ -180,12 +180,11 @@ func (d *requestDistributor) loop() {
 type selectPeerItem struct {
 	peer   distPeer
 	req    *distReq
-	weight int64
+	weight uint64
 }
 
-// Weight implements wrsItem interface
-func (sp selectPeerItem) Weight() int64 {
-	return sp.weight
+func selectPeerWeight(i interface{}) uint64 {
+	return i.(selectPeerItem).weight
 }
 
 // nextRequest returns the next possible request from any peer, along with the
@@ -220,9 +219,9 @@ func (d *requestDistributor) nextRequest() (distPeer, *distReq, time.Duration) {
 				wait, bufRemain := peer.waitBefore(cost)
 				if wait == 0 {
 					if sel == nil {
-						sel = utils.NewWeightedRandomSelect()
+						sel = utils.NewWeightedRandomSelect(selectPeerWeight)
 					}
-					sel.Update(selectPeerItem{peer: peer, req: req, weight: int64(bufRemain*1000000) + 1})
+					sel.Update(selectPeerItem{peer: peer, req: req, weight: uint64(bufRemain*1000000) + 1})
 				} else {
 					if bestWait == 0 || wait < bestWait {
 						bestWait = wait

--- a/les/enr_entry.go
+++ b/les/enr_entry.go
@@ -17,6 +17,9 @@
 package les
 
 import (
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/dnsdisc"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -29,4 +32,13 @@ type lesEntry struct {
 // ENRKey implements enr.Entry.
 func (e lesEntry) ENRKey() string {
 	return "les"
+}
+
+// setupDiscovery creates the node discovery source for the eth protocol.
+func (eth *LightEthereum) setupDiscovery(cfg *p2p.Config) (enode.Iterator, error) {
+	if /*cfg.NoDiscovery || */ len(eth.config.DiscoveryURLs) == 0 {
+		return nil, nil
+	}
+	client := dnsdisc.NewClient(dnsdisc.Config{})
+	return client.NewIterator(eth.config.DiscoveryURLs...)
 }

--- a/les/lespay/client/queueiterator.go
+++ b/les/lespay/client/queueiterator.go
@@ -1,0 +1,131 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package client
+
+import (
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/les/utils"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
+)
+
+// QueueIterator returns nodes from the specified selectable set in the same order as
+// they entered the set.
+type QueueIterator struct {
+	lock         sync.Mutex
+	ns           *utils.NodeStateMachine
+	queue        []enode.ID
+	selected     utils.NodeStateBitMask
+	enrFieldID   int
+	validSchemes enr.IdentityScheme
+	wakeup       chan struct{}
+	nextID       enode.ID
+	nextENR      *enr.Record
+	closed       bool
+}
+
+// NewQueueIterator creates a new QueueIterator. Nodes are selectable if they have all the required
+// and none of the disabled flags set. When a node is selected the selectedFlag is set which also
+// disables further selectability until it is removed or times out.
+// The ENR field should be set for all selectable nodes so that the iterator can return complete enodes.
+func NewQueueIterator(ns *utils.NodeStateMachine, requireMask, disableMask utils.NodeStateBitMask,
+	selectedFlag *utils.NodeStateFlag, enrField *utils.NodeStateField, validSchemes enr.IdentityScheme) *QueueIterator {
+
+	selected := ns.MustRegisterState(selectedFlag)
+	disableMask |= selected
+	qi := &QueueIterator{
+		ns:           ns,
+		selected:     selected,
+		enrFieldID:   ns.MustRegisterField(enrField),
+		validSchemes: validSchemes,
+	}
+	ns.AddStateSub(requireMask|disableMask, func(id enode.ID, oldState, newState utils.NodeStateBitMask) {
+		oldMatch := (oldState&requireMask == requireMask) && (oldState&disableMask == 0)
+		newMatch := (newState&requireMask == requireMask) && (newState&disableMask == 0)
+		if newMatch != oldMatch {
+			qi.lock.Lock()
+			if newMatch {
+				qi.queue = append(qi.queue, id)
+				if qi.wakeup != nil {
+					close(qi.wakeup)
+					qi.wakeup = nil
+				}
+			} else {
+				for i, qid := range qi.queue {
+					if qid == id {
+						copy(qi.queue[i:len(qi.queue)-1], qi.queue[i+1:])
+						qi.queue = qi.queue[:len(qi.queue)-1]
+						break
+					}
+				}
+			}
+			qi.lock.Unlock()
+		}
+	})
+	return qi
+}
+
+// Next implements enode.Iterator
+func (qi *QueueIterator) Next() bool {
+	qi.lock.Lock()
+	for {
+		if qi.closed {
+			qi.lock.Unlock()
+			return false
+		}
+		if len(qi.queue) > 0 {
+			qi.nextID = qi.queue[0]
+			e := qi.ns.GetField(qi.nextID, qi.enrFieldID)
+			var ok bool
+			if qi.nextENR, ok = e.(*enr.Record); ok {
+				copy(qi.queue[:len(qi.queue)-1], qi.queue[1:])
+				qi.queue = qi.queue[:len(qi.queue)-1]
+				qi.lock.Unlock()
+				qi.ns.UpdateState(qi.nextID, qi.selected, 0, time.Second*5)
+				return true
+			}
+		}
+		ch := make(chan struct{})
+		qi.wakeup = ch
+		qi.lock.Unlock()
+		<-ch
+		qi.lock.Lock()
+	}
+}
+
+// Close implements enode.Iterator
+func (qi *QueueIterator) Close() {
+	qi.lock.Lock()
+	defer qi.lock.Unlock()
+
+	qi.closed = true
+	if qi.wakeup != nil {
+		close(qi.wakeup)
+		qi.wakeup = nil
+	}
+}
+
+// Node implements enode.Iterator
+func (qi *QueueIterator) Node() *enode.Node {
+	qi.lock.Lock()
+	defer qi.lock.Unlock()
+
+	node, _ := enode.New(qi.validSchemes, qi.nextENR)
+	return node
+}

--- a/les/lespay/client/queueiterator.go
+++ b/les/lespay/client/queueiterator.go
@@ -55,7 +55,7 @@ func NewQueueIterator(ns *utils.NodeStateMachine, requireMask, disableMask utils
 		enrFieldID:   ns.MustRegisterField(enrField),
 		validSchemes: validSchemes,
 	}
-	ns.AddStateSub(requireMask|disableMask, func(id enode.ID, oldState, newState utils.NodeStateBitMask) {
+	ns.SubscribeStates(enode.ID{}, requireMask|disableMask, func(id enode.ID, oldState, newState utils.NodeStateBitMask) {
 		oldMatch := (oldState&requireMask == requireMask) && (oldState&disableMask == 0)
 		newMatch := (newState&requireMask == requireMask) && (newState&disableMask == 0)
 		if newMatch != oldMatch {

--- a/les/lespay/client/queueiterator_test.go
+++ b/les/lespay/client/queueiterator_test.go
@@ -1,0 +1,110 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package client
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/les/utils"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
+)
+
+var (
+	sfTest1 = utils.NewNodeStateFlag("test1", false, false)
+	sfTest2 = utils.NewNodeStateFlag("test2", false, false)
+	sfTest3 = utils.NewNodeStateFlag("test3", false, false)
+	sfTest4 = utils.NewNodeStateFlag("test4", false, false)
+	sfiEnr  = utils.NewNodeStateField("enr", reflect.TypeOf(&enr.Record{}), []*utils.NodeStateFlag{sfTest1}, nil, nil)
+)
+
+const iterTestNodeCount = 6
+
+func testNodeID(i int) enode.ID {
+	return enode.ID{42, byte(i % 256), byte(i / 256)}
+}
+
+func testNodeIndex(id enode.ID) int {
+	if id[0] != 42 {
+		return -1
+	}
+	return int(id[1]) + int(id[2])*256
+}
+
+func TestQueueIterator(t *testing.T) {
+	ns := utils.NewNodeStateMachine(nil, nil, &mclock.Simulated{})
+	st1 := ns.MustRegisterState(sfTest1)
+	st2 := ns.MustRegisterState(sfTest2)
+	st3 := ns.MustRegisterState(sfTest3)
+	st4 := ns.MustRegisterState(sfTest4)
+	enrField := ns.MustRegisterField(sfiEnr)
+	qi := NewQueueIterator(ns, st2, st3, sfTest4, sfiEnr, enode.ValidSchemesForTesting)
+	ns.Start()
+	for i := 1; i <= iterTestNodeCount; i++ {
+		node := enode.SignNull(&enr.Record{}, testNodeID(i))
+		ns.UpdateState(node.ID(), st1, 0, 0)
+		ns.SetField(node.ID(), enrField, node.Record())
+	}
+	ch := make(chan *enode.Node)
+	go func() {
+		for qi.Next() {
+			ch <- qi.Node()
+		}
+		close(ch)
+	}()
+	next := func() int {
+		select {
+		case node := <-ch:
+			return testNodeIndex(node.ID())
+		case <-time.After(time.Millisecond * 200):
+			return 0
+		}
+	}
+	exp := func(i int) {
+		n := next()
+		if n != i {
+			t.Errorf("Wrong item returned by iterator (expected %d, got %d)", i, n)
+		}
+	}
+	exp(0)
+	ns.UpdateState(testNodeID(1), st2, 0, 0)
+	ns.UpdateState(testNodeID(2), st2, 0, 0)
+	ns.UpdateState(testNodeID(3), st2, 0, 0)
+	exp(1)
+	exp(2)
+	exp(3)
+	exp(0)
+	ns.UpdateState(testNodeID(4), st2, 0, 0)
+	ns.UpdateState(testNodeID(5), st2, 0, 0)
+	ns.UpdateState(testNodeID(6), st2, 0, 0)
+	ns.UpdateState(testNodeID(5), st3, 0, 0)
+	exp(4)
+	exp(6)
+	exp(0)
+	ns.UpdateState(testNodeID(1), 0, st4, 0)
+	ns.UpdateState(testNodeID(2), 0, st4, 0)
+	ns.UpdateState(testNodeID(3), 0, st4, 0)
+	ns.UpdateState(testNodeID(2), st3, 0, 0)
+	ns.UpdateState(testNodeID(2), 0, st3, 0)
+	exp(1)
+	exp(3)
+	exp(2)
+	exp(0)
+}

--- a/les/lespay/client/valuetracker.go
+++ b/les/lespay/client/valuetracker.go
@@ -213,6 +213,15 @@ func (vt *ValueTracker) StatsExpirer() *utils.Expirer {
 	return &vt.statsExpirer
 }
 
+// StatsExpirer returns the current expiration factor so that other values can be expired
+// with the same rate as the service value statistics.
+func (vt *ValueTracker) StatsExpFactor() utils.ExpirationFactor {
+	vt.lock.Lock()
+	defer vt.lock.Unlock()
+
+	return vt.statsExpFactor
+}
+
 // loadFromDb loads the value tracker's state from the database and converts saved
 // request basket index mapping if it does not match the specified index to name mapping.
 func (vt *ValueTracker) loadFromDb(mapping []string) error {

--- a/les/lespay/client/wrsiterator.go
+++ b/les/lespay/client/wrsiterator.go
@@ -58,7 +58,7 @@ func NewWrsIterator(ns *utils.NodeStateMachine, requireMask, disableMask utils.N
 		enrFieldID:   ns.MustRegisterField(enrField),
 		validSchemes: validSchemes,
 	}
-	ns.AddStateSub(requireMask|disableMask, func(id enode.ID, oldState, newState utils.NodeStateBitMask) {
+	ns.SubscribeStates(enode.ID{}, requireMask|disableMask, func(id enode.ID, oldState, newState utils.NodeStateBitMask) {
 		ps := (oldState&w.disableMask) == 0 && (oldState&w.requireMask) == w.requireMask
 		ns := (newState&w.disableMask) == 0 && (newState&w.requireMask) == w.requireMask
 

--- a/les/lespay/client/wrsiterator.go
+++ b/les/lespay/client/wrsiterator.go
@@ -1,0 +1,131 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package client
+
+import (
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/les/utils"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
+)
+
+// WrsIterator returns nodes from the specified selectable set with a weighted random
+// selection. Selection weights are provided by a callback function.
+type WrsIterator struct {
+	lock                               sync.Mutex
+	ns                                 *utils.NodeStateMachine
+	wrs                                *utils.WeightedRandomSelect
+	requireMask, disableMask, selected utils.NodeStateBitMask
+	enrFieldID                         int
+	validSchemes                       enr.IdentityScheme
+	wakeup                             chan struct{}
+	nextID                             enode.ID
+	nextENR                            *enr.Record
+	closed                             bool
+}
+
+// NewWrsIterator creates a new WrsIterator. Nodes are selectable if they have all the required
+// and none of the disabled flags set. When a node is selected the selectedFlag is set which also
+// disables further selectability until it is removed or times out.
+// The ENR field should be set for all selectable nodes so that the iterator can return complete enodes.
+func NewWrsIterator(ns *utils.NodeStateMachine, requireMask, disableMask utils.NodeStateBitMask, selectedFlag *utils.NodeStateFlag,
+	enrField *utils.NodeStateField, wfn func(interface{}) uint64, validSchemes enr.IdentityScheme) *WrsIterator {
+
+	selected := ns.MustRegisterState(selectedFlag)
+	disableMask |= selected
+	w := &WrsIterator{
+		ns:           ns,
+		wrs:          utils.NewWeightedRandomSelect(wfn),
+		requireMask:  requireMask,
+		disableMask:  disableMask,
+		selected:     selected,
+		enrFieldID:   ns.MustRegisterField(enrField),
+		validSchemes: validSchemes,
+	}
+	ns.AddStateSub(requireMask|disableMask, func(id enode.ID, oldState, newState utils.NodeStateBitMask) {
+		ps := (oldState&w.disableMask) == 0 && (oldState&w.requireMask) == w.requireMask
+		ns := (newState&w.disableMask) == 0 && (newState&w.requireMask) == w.requireMask
+
+		w.lock.Lock()
+		defer w.lock.Unlock()
+
+		if ps == ns {
+			return
+		}
+		if ns {
+			w.wrs.Update(id)
+			if w.wakeup != nil && !w.wrs.IsEmpty() {
+				close(w.wakeup)
+				w.wakeup = nil
+			}
+		} else {
+			w.wrs.Remove(id)
+		}
+	})
+	return w
+}
+
+// Next implements enode.Iterator
+func (w *WrsIterator) Next() bool {
+	w.lock.Lock()
+	for {
+		if w.closed {
+			w.lock.Unlock()
+			return false
+		}
+		n := w.wrs.Choose()
+		if n != nil {
+			w.nextID = n.(enode.ID)
+			e := w.ns.GetField(w.nextID, w.enrFieldID)
+			var ok bool
+			if w.nextENR, ok = e.(*enr.Record); ok {
+				w.lock.Unlock()
+				w.ns.UpdateState(w.nextID, w.selected, 0, time.Second*5)
+				return true
+			}
+		}
+		ch := make(chan struct{})
+		w.wakeup = ch
+		w.lock.Unlock()
+		<-ch
+		w.lock.Lock()
+	}
+}
+
+// Close implements enode.Iterator
+func (w *WrsIterator) Close() {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	w.closed = true
+	if w.wakeup != nil {
+		close(w.wakeup)
+		w.wakeup = nil
+	}
+}
+
+// Node implements enode.Iterator
+func (w *WrsIterator) Node() *enode.Node {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	//	node, _ := enode.New(enode.V4ID{}, w.nextENR)
+	node, _ := enode.New(w.validSchemes, w.nextENR)
+	return node
+}

--- a/les/lespay/client/wrsiterator_test.go
+++ b/les/lespay/client/wrsiterator_test.go
@@ -1,0 +1,124 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package client
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/les/utils"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
+)
+
+func TestWrsIterator(t *testing.T) {
+	ns := utils.NewNodeStateMachine(nil, nil, &mclock.Simulated{})
+	st1 := ns.MustRegisterState(sfTest1)
+	st2 := ns.MustRegisterState(sfTest2)
+	st3 := ns.MustRegisterState(sfTest3)
+	st4 := ns.MustRegisterState(sfTest4)
+	enrField := ns.MustRegisterField(sfiEnr)
+	weights := make([]uint64, iterTestNodeCount+1)
+	wfn := func(i interface{}) uint64 {
+		id := i.(enode.ID)
+		idx := testNodeIndex(id)
+		if idx <= 0 || idx > len(weights) {
+			t.Errorf("Invalid node id %v", id)
+		}
+		return weights[idx]
+	}
+	w := NewWrsIterator(ns, st2, st3, sfTest4, sfiEnr, wfn, enode.ValidSchemesForTesting)
+	ns.Start()
+	for i := 1; i <= iterTestNodeCount; i++ {
+		weights[i] = 1
+		node := enode.SignNull(&enr.Record{}, testNodeID(i))
+		ns.UpdateState(node.ID(), st1, 0, 0)
+		ns.SetField(node.ID(), enrField, node.Record())
+	}
+	ch := make(chan *enode.Node)
+	go func() {
+		for w.Next() {
+			ch <- w.Node()
+		}
+		close(ch)
+	}()
+	next := func() int {
+		select {
+		case node := <-ch:
+			return testNodeIndex(node.ID())
+		case <-time.After(time.Millisecond * 200):
+			return 0
+		}
+	}
+	exp := func(i int) {
+		n := next()
+		if n != i {
+			t.Errorf("Wrong item returned by iterator (expected %d, got %d)", i, n)
+		}
+	}
+	set := make(map[int]bool)
+	expset := func() {
+		n := next()
+		if !set[n] {
+			t.Errorf("Item returned by iterator not in the expected set (got %d)", n)
+		}
+		delete(set, n)
+	}
+
+	exp(0)
+	ns.UpdateState(testNodeID(1), st2, 0, 0)
+	ns.UpdateState(testNodeID(2), st2, 0, 0)
+	ns.UpdateState(testNodeID(3), st2, 0, 0)
+	set[1] = true
+	set[2] = true
+	set[3] = true
+	expset()
+	expset()
+	expset()
+	exp(0)
+	ns.UpdateState(testNodeID(4), st2, 0, 0)
+	ns.UpdateState(testNodeID(5), st2, 0, 0)
+	ns.UpdateState(testNodeID(6), st2, 0, 0)
+	ns.UpdateState(testNodeID(5), st3, 0, 0)
+	set[4] = true
+	set[6] = true
+	expset()
+	expset()
+	exp(0)
+	ns.UpdateState(testNodeID(1), 0, st4, 0)
+	ns.UpdateState(testNodeID(2), 0, st4, 0)
+	ns.UpdateState(testNodeID(3), 0, st4, 0)
+	weights[2] = 0
+	set[1] = true
+	set[3] = true
+	expset()
+	expset()
+	exp(0)
+	weights[2] = 1
+	ns.UpdateState(testNodeID(2), 0, st2, 0)
+	ns.UpdateState(testNodeID(1), 0, st4, 0)
+	ns.UpdateState(testNodeID(2), st2, st4, 0)
+	ns.UpdateState(testNodeID(3), 0, st4, 0)
+	set[1] = true
+	set[2] = true
+	set[3] = true
+	expset()
+	expset()
+	expset()
+	exp(0)
+}

--- a/les/peer.go
+++ b/les/peer.go
@@ -357,7 +357,6 @@ type serverPeer struct {
 	checkpointNumber uint64                   // The block height which the checkpoint is registered.
 	checkpoint       params.TrustedCheckpoint // The advertised checkpoint sent by server.
 
-	poolEntry        *poolEntry              // Statistic for server peer.
 	fcServer         *flowcontrol.ServerNode // Client side mirror token bucket.
 	vtLock           sync.Mutex
 	valueTracker     *lpc.ValueTracker

--- a/les/protocol.go
+++ b/les/protocol.go
@@ -130,7 +130,6 @@ func init() {
 		}
 		requestMapping[uint32(code)] = rm
 	}
-
 }
 
 type errCode int

--- a/les/server.go
+++ b/les/server.go
@@ -157,7 +157,7 @@ func (s *LesServer) Protocols() []p2p.Protocol {
 			return p.Info()
 		}
 		return nil
-	})
+	}, nil)
 	// Add "les" ENR entries.
 	for i := range ps {
 		ps[i].Attributes = []enr.Entry{&lesEntry{}}

--- a/les/serverpool.go
+++ b/les/serverpool.go
@@ -60,8 +60,8 @@ type serverPool struct {
 	timeoutRefreshed mclock.AbsTime
 }
 
-// nodeHistory keeps track of dial costs which determine node weight together with the
-// service value calculated by lpc.ValueTracker.
+// nodeHistory keeps track of dial costs which determine node weight
+// together with the service value calculated by lpc.ValueTracker.
 type nodeHistory struct {
 	// only dialCost is saved
 	lock        sync.Mutex
@@ -76,16 +76,24 @@ var (
 	sfSelected      = utils.NewNodeStateFlag("selected", false, false)
 	sfDialed        = utils.NewNodeStateFlag("dialed", false, false)
 	sfConnected     = utils.NewNodeStateFlag("connected", false, false)
-	sfRedialWait    = utils.NewNodeStateFlag("redialWait", false, true)
+	sfRedialWait    = utils.NewNodeStateFlag("redialWait", false, false)
 	sfAlwaysConnect = utils.NewNodeStateFlag("alwaysConnect", false, false)
 
-	keepNodeRecord   = []*utils.NodeStateFlag{sfDiscovered, sfHasValue, sfAlwaysConnect}
+	// keepNodeRecord is a group of state flags. If any
+	// flag is set, then the node record should be kept.
+	keepNodeRecord = []*utils.NodeStateFlag{sfDiscovered, sfHasValue, sfAlwaysConnect}
+
+	// disableSelection is a group of state flags. If any
+	// flag is set, then the node is considered as selected
+	// and won't be selected for further network activities.
 	disableSelection = []*utils.NodeStateFlag{sfSelected, sfDialed, sfConnected, sfRedialWait}
 
 	errInvalidField = errors.New("invalid field type")
 
 	sfiEnr = utils.NewNodeStateField("enr", reflect.TypeOf(&enr.Record{}), keepNodeRecord,
 		func(field interface{}) ([]byte, error) {
+			// todo(rjl493456442) enr record can only
+			// be RLP-encoded when the record is signed
 			if e, ok := field.(*enr.Record); ok {
 				enc, err := rlp.EncodeToBytes(e)
 				return enc, err

--- a/les/serverpool.go
+++ b/les/serverpool.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The go-ethereum Authors
+// Copyright 2020 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
 // The go-ethereum library is free software: you can redistribute it and/or modify
@@ -17,904 +17,283 @@
 package les
 
 import (
-	"crypto/ecdsa"
-	"fmt"
-	"io"
-	"math"
-	"math/rand"
-	"net"
-	"strconv"
+	"errors"
+	"reflect"
 	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/mclock"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethdb"
+	lpc "github.com/ethereum/go-ethereum/les/lespay/client"
 	"github.com/ethereum/go-ethereum/les/utils"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/p2p"
-	"github.com/ethereum/go-ethereum/p2p/discv5"
 	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
 const (
-	// After a connection has been ended or timed out, there is a waiting period
-	// before it can be selected for connection again.
-	// waiting period = base delay * (1 + random(1))
-	// base delay = shortRetryDelay for the first shortRetryCnt times after a
-	// successful connection, after that longRetryDelay is applied
-	shortRetryCnt   = 5
-	shortRetryDelay = time.Second * 5
-	longRetryDelay  = time.Minute * 10
-	// maxNewEntries is the maximum number of newly discovered (never connected) nodes.
-	// If the limit is reached, the least recently discovered one is thrown out.
-	maxNewEntries = 1000
-	// maxKnownEntries is the maximum number of known (already connected) nodes.
-	// If the limit is reached, the least recently connected one is thrown out.
-	// (not that unlike new entries, known entries are persistent)
-	maxKnownEntries = 1000
-	// target for simultaneously connected servers
-	targetServerCount = 5
-	// target for servers selected from the known table
-	// (we leave room for trying new ones if there is any)
-	targetKnownSelect = 3
-	// after dialTimeout, consider the server unavailable and adjust statistics
-	dialTimeout = time.Second * 30
-	// targetConnTime is the minimum expected connection duration before a server
-	// drops a client without any specific reason
-	targetConnTime = time.Minute * 10
-	// new entry selection weight calculation based on most recent discovery time:
-	// unity until discoverExpireStart, then exponential decay with discoverExpireConst
-	discoverExpireStart = time.Minute * 20
-	discoverExpireConst = time.Minute * 20
-	// known entry selection weight is dropped by a factor of exp(-failDropLn) after
-	// each unsuccessful connection (restored after a successful one)
-	failDropLn = 0.1
-	// known node connection success and quality statistics have a long term average
-	// and a short term value which is adjusted exponentially with a factor of
-	// pstatRecentAdjust with each dial/connection and also returned exponentially
-	// to the average with the time constant pstatReturnToMeanTC
-	pstatReturnToMeanTC = time.Hour
-	// node address selection weight is dropped by a factor of exp(-addrFailDropLn) after
-	// each unsuccessful connection (restored after a successful one)
-	addrFailDropLn = math.Ln2
-	// responseScoreTC and delayScoreTC are exponential decay time constants for
-	// calculating selection chances from response times and block delay times
-	responseScoreTC = time.Millisecond * 100
-	delayScoreTC    = time.Second * 5
-	timeoutPow      = 10
-	// initStatsWeight is used to initialize previously unknown peers with good
-	// statistics to give a chance to prove themselves
-	initStatsWeight = 1
+	minTimeout             = time.Millisecond * 500 // minimum request timeout suggested by the server pool
+	timeoutRefresh         = time.Second * 5        // recalculate timeout if older than this
+	timeoutChangeThreshold = time.Millisecond * 10  // recalculate node values if timeout has changed more than this amount
+	dialCost               = 10000                  // cost of a TCP dial (used for known node selection weight calculation)
+	nodeWeightMul          = 1000000                // multiplier constant for node weight calculation
+	nodeWeightThreshold    = 100                    // minimum weight for keeping a node in the the known (valuable) set
 )
 
-// connReq represents a request for peer connection.
-type connReq struct {
-	p      *serverPeer
-	node   *enode.Node
-	result chan *poolEntry
-}
-
-// disconnReq represents a request for peer disconnection.
-type disconnReq struct {
-	entry   *poolEntry
-	stopped bool
-	done    chan struct{}
-}
-
-// registerReq represents a request for peer registration.
-type registerReq struct {
-	entry *poolEntry
-	done  chan struct{}
-}
-
-// serverPool implements a pool for storing and selecting newly discovered and already
-// known light server nodes. It received discovered nodes, stores statistics about
-// known nodes and takes care of always having enough good quality servers connected.
+// serverPool provides a node iterator for dial candidates. The output is a mix of newly discovered
+// nodes, a weighted random selection of known (previously valuable) nodes and trusted/paid nodes.
 type serverPool struct {
-	db     ethdb.Database
-	dbKey  []byte
-	server *p2p.Server
-	connWg sync.WaitGroup
+	clock                               mclock.Clock
+	ns                                  *utils.NodeStateMachine
+	vt                                  *lpc.ValueTracker
+	mixer                               *enode.FairMix
+	mixSources                          []enode.Iterator
+	dialIterator                        enode.Iterator
+	stDialed, stConnected, stRedialWait utils.NodeStateBitMask
+	stHasValue, stAlwaysConnect         utils.NodeStateBitMask
+	enrFieldId, nodeHistoryFieldId      int
+	trusted                             []enode.ID
 
-	topic discv5.Topic
-
-	discSetPeriod chan time.Duration
-	discNodes     chan *enode.Node
-	discLookups   chan bool
-
-	trustedNodes         map[enode.ID]*enode.Node
-	entries              map[enode.ID]*poolEntry
-	timeout, enableRetry chan *poolEntry
-	adjustStats          chan poolStatAdjust
-
-	knownQueue, newQueue       poolEntryQueue
-	knownSelect, newSelect     *utils.WeightedRandomSelect
-	knownSelected, newSelected int
-	fastDiscover               bool
-	connCh                     chan *connReq
-	disconnCh                  chan *disconnReq
-	registerCh                 chan *registerReq
-
-	closeCh chan struct{}
-	wg      sync.WaitGroup
+	timeoutLock      sync.RWMutex
+	timeout          time.Duration
+	timeWeights      lpc.ResponseTimeWeights
+	timeoutRefreshed mclock.AbsTime
 }
 
-// newServerPool creates a new serverPool instance
-func newServerPool(db ethdb.Database, ulcServers []string) *serverPool {
-	pool := &serverPool{
-		db:           db,
-		entries:      make(map[enode.ID]*poolEntry),
-		timeout:      make(chan *poolEntry, 1),
-		adjustStats:  make(chan poolStatAdjust, 100),
-		enableRetry:  make(chan *poolEntry, 1),
-		connCh:       make(chan *connReq),
-		disconnCh:    make(chan *disconnReq),
-		registerCh:   make(chan *registerReq),
-		closeCh:      make(chan struct{}),
-		knownSelect:  utils.NewWeightedRandomSelect(),
-		newSelect:    utils.NewWeightedRandomSelect(),
-		fastDiscover: true,
-		trustedNodes: parseTrustedNodes(ulcServers),
-	}
-
-	pool.knownQueue = newPoolEntryQueue(maxKnownEntries, pool.removeEntry)
-	pool.newQueue = newPoolEntryQueue(maxNewEntries, pool.removeEntry)
-	return pool
+// nodeHistory keeps track of dial costs which determine node weight together with the
+// service value calculated by lpc.ValueTracker.
+type nodeHistory struct {
+	// only dialCost is saved
+	lock        sync.Mutex
+	dialCost    utils.ExpiredValue
+	lastTimeout time.Duration
+	totalValue  float64
 }
 
-func (pool *serverPool) start(server *p2p.Server, topic discv5.Topic) {
-	pool.server = server
-	pool.topic = topic
-	pool.dbKey = append([]byte("serverPool/"), []byte(topic)...)
-	pool.loadNodes()
-	pool.connectToTrustedNodes()
+var (
+	sfDiscovered    = utils.NewNodeStateFlag("discovered", false, false)
+	sfHasValue      = utils.NewNodeStateFlag("hasValue", true, false)
+	sfSelected      = utils.NewNodeStateFlag("selected", false, false)
+	sfDialed        = utils.NewNodeStateFlag("dialed", false, false)
+	sfConnected     = utils.NewNodeStateFlag("connected", false, false)
+	sfRedialWait    = utils.NewNodeStateFlag("redialWait", false, true)
+	sfAlwaysConnect = utils.NewNodeStateFlag("alwaysConnect", false, false)
 
-	if pool.server.DiscV5 != nil {
-		pool.discSetPeriod = make(chan time.Duration, 1)
-		pool.discNodes = make(chan *enode.Node, 100)
-		pool.discLookups = make(chan bool, 100)
-		go pool.discoverNodes()
-	}
-	pool.checkDial()
-	pool.wg.Add(1)
-	go pool.eventLoop()
+	keepNodeRecord   = []*utils.NodeStateFlag{sfDiscovered, sfHasValue, sfAlwaysConnect}
+	disableSelection = []*utils.NodeStateFlag{sfSelected, sfDialed, sfConnected, sfRedialWait}
 
-	// Inject the bootstrap nodes as initial dial candiates.
-	pool.wg.Add(1)
-	go func() {
-		defer pool.wg.Done()
-		for _, n := range server.BootstrapNodes {
-			select {
-			case pool.discNodes <- n:
-			case <-pool.closeCh:
-				return
+	errInvalidField = errors.New("invalid field type")
+
+	sfiEnr = utils.NewNodeStateField("enr", reflect.TypeOf(&enr.Record{}), keepNodeRecord,
+		func(field interface{}) ([]byte, error) {
+			if e, ok := field.(*enr.Record); ok {
+				enc, err := rlp.EncodeToBytes(e)
+				return enc, err
+			} else {
+				return nil, errInvalidField
 			}
-		}
-	}()
-}
-
-func (pool *serverPool) stop() {
-	close(pool.closeCh)
-	pool.wg.Wait()
-}
-
-// discoverNodes wraps SearchTopic, converting result nodes to enode.Node.
-func (pool *serverPool) discoverNodes() {
-	ch := make(chan *discv5.Node)
-	go func() {
-		pool.server.DiscV5.SearchTopic(pool.topic, pool.discSetPeriod, ch, pool.discLookups)
-		close(ch)
-	}()
-	for n := range ch {
-		pubkey, err := decodePubkey64(n.ID[:])
-		if err != nil {
-			continue
-		}
-		pool.discNodes <- enode.NewV4(pubkey, n.IP, int(n.TCP), int(n.UDP))
-	}
-}
-
-// connect should be called upon any incoming connection. If the connection has been
-// dialed by the server pool recently, the appropriate pool entry is returned.
-// Otherwise, the connection should be rejected.
-// Note that whenever a connection has been accepted and a pool entry has been returned,
-// disconnect should also always be called.
-func (pool *serverPool) connect(p *serverPeer, node *enode.Node) *poolEntry {
-	log.Debug("Connect new entry", "enode", p.id)
-	req := &connReq{p: p, node: node, result: make(chan *poolEntry, 1)}
-	select {
-	case pool.connCh <- req:
-	case <-pool.closeCh:
-		return nil
-	}
-	return <-req.result
-}
-
-// registered should be called after a successful handshake
-func (pool *serverPool) registered(entry *poolEntry) {
-	log.Debug("Registered new entry", "enode", entry.node.ID())
-	req := &registerReq{entry: entry, done: make(chan struct{})}
-	select {
-	case pool.registerCh <- req:
-	case <-pool.closeCh:
-		return
-	}
-	<-req.done
-}
-
-// disconnect should be called when ending a connection. Service quality statistics
-// can be updated optionally (not updated if no registration happened, in this case
-// only connection statistics are updated, just like in case of timeout)
-func (pool *serverPool) disconnect(entry *poolEntry) {
-	stopped := false
-	select {
-	case <-pool.closeCh:
-		stopped = true
-	default:
-	}
-	log.Debug("Disconnected old entry", "enode", entry.node.ID())
-	req := &disconnReq{entry: entry, stopped: stopped, done: make(chan struct{})}
-
-	// Block until disconnection request is served.
-	pool.disconnCh <- req
-	<-req.done
-}
-
-const (
-	pseBlockDelay = iota
-	pseResponseTime
-	pseResponseTimeout
+		},
+		func(enc []byte) (interface{}, error) {
+			e := &enr.Record{}
+			err := rlp.DecodeBytes(enc, e)
+			return e, err
+		},
+	)
+	sfiNodeHistory = utils.NewNodeStateField("nodeHistory", reflect.TypeOf(&nodeHistory{}), []*utils.NodeStateFlag{sfDiscovered, sfHasValue},
+		func(field interface{}) ([]byte, error) {
+			if n, ok := field.(*nodeHistory); ok {
+				enc, err := rlp.EncodeToBytes(&n.dialCost)
+				return enc, err
+			} else {
+				return nil, errInvalidField
+			}
+		},
+		func(enc []byte) (interface{}, error) {
+			n := &nodeHistory{}
+			err := rlp.DecodeBytes(enc, &n.dialCost)
+			return n, err
+		},
+	)
 )
 
-// poolStatAdjust records are sent to adjust peer block delay/response time statistics
-type poolStatAdjust struct {
-	adjustType int
-	entry      *poolEntry
-	time       time.Duration
-}
-
-// adjustBlockDelay adjusts the block announce delay statistics of a node
-func (pool *serverPool) adjustBlockDelay(entry *poolEntry, time time.Duration) {
-	if entry == nil {
-		return
+// newServerPool creates a new server pool
+func newServerPool(ns *utils.NodeStateMachine, vt *lpc.ValueTracker, discovery enode.Iterator, clock mclock.Clock, trustedURLs []string, testing bool) *serverPool {
+	s := &serverPool{
+		clock: clock,
+		ns:    ns,
+		vt:    vt,
 	}
-	pool.adjustStats <- poolStatAdjust{pseBlockDelay, entry, time}
-}
+	s.getTimeout()
+	// Register all serverpool-defined states
+	stDiscovered := s.ns.MustRegisterState(sfDiscovered)
+	s.stHasValue = s.ns.MustRegisterState(sfHasValue)
+	s.stDialed = s.ns.MustRegisterState(sfDialed)
+	s.stConnected = s.ns.MustRegisterState(sfConnected)
+	s.stRedialWait = s.ns.MustRegisterState(sfRedialWait)
+	s.stAlwaysConnect = s.ns.MustRegisterState(sfAlwaysConnect)
+	s.ns.MustRegisterState(sfSelected)
 
-// adjustResponseTime adjusts the request response time statistics of a node
-func (pool *serverPool) adjustResponseTime(entry *poolEntry, time time.Duration, timeout bool) {
-	if entry == nil {
-		return
-	}
-	if timeout {
-		pool.adjustStats <- poolStatAdjust{pseResponseTimeout, entry, time}
+	// Register all serverpool-defined node fields.
+	s.enrFieldId = s.ns.MustRegisterField(sfiEnr)
+	s.nodeHistoryFieldId = s.ns.MustRegisterField(sfiNodeHistory)
+
+	var (
+		validSchemes enr.IdentityScheme
+		mixerTimeout time.Duration
+	)
+	if testing {
+		validSchemes = enode.ValidSchemesForTesting
 	} else {
-		pool.adjustStats <- poolStatAdjust{pseResponseTime, entry, time}
-	}
-}
-
-// eventLoop handles pool events and mutex locking for all internal functions
-func (pool *serverPool) eventLoop() {
-	defer pool.wg.Done()
-	lookupCnt := 0
-	var convTime mclock.AbsTime
-	if pool.discSetPeriod != nil {
-		pool.discSetPeriod <- time.Millisecond * 100
+		validSchemes = enode.ValidSchemes
+		mixerTimeout = time.Second
 	}
 
-	// disconnect updates service quality statistics depending on the connection time
-	// and disconnection initiator.
-	disconnect := func(req *disconnReq, stopped bool) {
-		// Handle peer disconnection requests.
-		entry := req.entry
-		if entry.state == psRegistered {
-			connAdjust := float64(mclock.Now()-entry.regTime) / float64(targetConnTime)
-			if connAdjust > 1 {
-				connAdjust = 1
-			}
-			if stopped {
-				// disconnect requested by ourselves.
-				entry.connectStats.add(1, connAdjust)
-			} else {
-				// disconnect requested by server side.
-				entry.connectStats.add(connAdjust, 1)
-			}
-		}
-		entry.state = psNotConnected
-
-		if entry.knownSelected {
-			pool.knownSelected--
+	for _, url := range trustedURLs {
+		if node, err := enode.Parse(validSchemes, url); err == nil {
+			s.trusted = append(s.trusted, node.ID())
 		} else {
-			pool.newSelected--
-		}
-		pool.setRetryDial(entry)
-		pool.connWg.Done()
-		close(req.done)
-	}
-
-	for {
-		select {
-		case entry := <-pool.timeout:
-			if !entry.removed {
-				pool.checkDialTimeout(entry)
-			}
-
-		case entry := <-pool.enableRetry:
-			if !entry.removed {
-				entry.delayedRetry = false
-				pool.updateCheckDial(entry)
-			}
-
-		case adj := <-pool.adjustStats:
-			switch adj.adjustType {
-			case pseBlockDelay:
-				adj.entry.delayStats.add(float64(adj.time), 1)
-			case pseResponseTime:
-				adj.entry.responseStats.add(float64(adj.time), 1)
-				adj.entry.timeoutStats.add(0, 1)
-			case pseResponseTimeout:
-				adj.entry.timeoutStats.add(1, 1)
-			}
-
-		case node := <-pool.discNodes:
-			if pool.trustedNodes[node.ID()] == nil {
-				entry := pool.findOrNewNode(node)
-				pool.updateCheckDial(entry)
-			}
-
-		case conv := <-pool.discLookups:
-			if conv {
-				if lookupCnt == 0 {
-					convTime = mclock.Now()
-				}
-				lookupCnt++
-				if pool.fastDiscover && (lookupCnt == 50 || time.Duration(mclock.Now()-convTime) > time.Minute) {
-					pool.fastDiscover = false
-					if pool.discSetPeriod != nil {
-						pool.discSetPeriod <- time.Minute
-					}
-				}
-			}
-
-		case req := <-pool.connCh:
-			if pool.trustedNodes[req.p.ID()] != nil {
-				// ignore trusted nodes
-				req.result <- &poolEntry{trusted: true}
-			} else {
-				// Handle peer connection requests.
-				entry := pool.entries[req.p.ID()]
-				if entry == nil {
-					entry = pool.findOrNewNode(req.node)
-				}
-				if entry.state == psConnected || entry.state == psRegistered {
-					req.result <- nil
-					continue
-				}
-				pool.connWg.Add(1)
-				entry.peer = req.p
-				entry.state = psConnected
-				addr := &poolEntryAddress{
-					ip:       req.node.IP(),
-					port:     uint16(req.node.TCP()),
-					lastSeen: mclock.Now(),
-				}
-				entry.lastConnected = addr
-				entry.addr = make(map[string]*poolEntryAddress)
-				entry.addr[addr.strKey()] = addr
-				entry.addrSelect = *utils.NewWeightedRandomSelect()
-				entry.addrSelect.Update(addr)
-				req.result <- entry
-			}
-
-		case req := <-pool.registerCh:
-			if req.entry.trusted {
-				continue
-			}
-			// Handle peer registration requests.
-			entry := req.entry
-			entry.state = psRegistered
-			entry.regTime = mclock.Now()
-			if !entry.known {
-				pool.newQueue.remove(entry)
-				entry.known = true
-			}
-			pool.knownQueue.setLatest(entry)
-			entry.shortRetry = shortRetryCnt
-			close(req.done)
-
-		case req := <-pool.disconnCh:
-			if req.entry.trusted {
-				continue
-			}
-			// Handle peer disconnection requests.
-			disconnect(req, req.stopped)
-
-		case <-pool.closeCh:
-			if pool.discSetPeriod != nil {
-				close(pool.discSetPeriod)
-			}
-
-			// Spawn a goroutine to close the disconnCh after all connections are disconnected.
-			go func() {
-				pool.connWg.Wait()
-				close(pool.disconnCh)
-			}()
-
-			// Handle all remaining disconnection requests before exit.
-			for req := range pool.disconnCh {
-				disconnect(req, true)
-			}
-			pool.saveNodes()
-			return
+			log.Error("Invalid trusted server URL", "url", url, "error", err)
 		}
 	}
-}
 
-func (pool *serverPool) findOrNewNode(node *enode.Node) *poolEntry {
-	now := mclock.Now()
-	entry := pool.entries[node.ID()]
-	if entry == nil {
-		log.Debug("Discovered new entry", "id", node.ID())
-		entry = &poolEntry{
-			node:       node,
-			addr:       make(map[string]*poolEntryAddress),
-			addrSelect: *utils.NewWeightedRandomSelect(),
-			shortRetry: shortRetryCnt,
+	s.mixer = enode.NewFairMix(mixerTimeout)
+	knownSelector := lpc.NewWrsIterator(s.ns, s.stHasValue, s.ns.StatesMask(disableSelection), sfSelected, sfiEnr, s.knownSelectWeight, validSchemes)
+	alwaysConnect := lpc.NewQueueIterator(s.ns, s.stAlwaysConnect, s.ns.StatesMask(disableSelection), sfSelected, sfiEnr, validSchemes)
+	s.mixSources = append(s.mixSources, knownSelector)
+	s.mixSources = append(s.mixSources, alwaysConnect)
+	if discovery != nil {
+		discEnrStored := enode.Filter(discovery, func(node *enode.Node) bool {
+			s.ns.UpdateState(node.ID(), stDiscovered, 0, time.Hour)
+			s.ns.SetField(node.ID(), s.enrFieldId, node.Record())
+			return true
+		})
+		s.mixSources = append(s.mixSources, discEnrStored)
+	}
+
+	// preNegotiationFilter will be added in series with iter here when les4 is available
+
+	s.dialIterator = enode.Filter(s.mixer, func(node *enode.Node) bool {
+		n, _ := s.ns.GetField(node.ID(), s.nodeHistoryFieldId).(*nodeHistory)
+		if n == nil {
+			n = &nodeHistory{}
+			s.ns.SetField(node.ID(), s.nodeHistoryFieldId, n)
 		}
-		pool.entries[node.ID()] = entry
-		// initialize previously unknown peers with good statistics to give a chance to prove themselves
-		entry.connectStats.add(1, initStatsWeight)
-		entry.delayStats.add(0, initStatsWeight)
-		entry.responseStats.add(0, initStatsWeight)
-		entry.timeoutStats.add(0, initStatsWeight)
-	}
-	entry.lastDiscovered = now
-	addr := &poolEntryAddress{ip: node.IP(), port: uint16(node.TCP())}
-	if a, ok := entry.addr[addr.strKey()]; ok {
-		addr = a
-	} else {
-		entry.addr[addr.strKey()] = addr
-	}
-	addr.lastSeen = now
-	entry.addrSelect.Update(addr)
-	if !entry.known {
-		pool.newQueue.setLatest(entry)
-	}
-	return entry
-}
-
-// loadNodes loads known nodes and their statistics from the database
-func (pool *serverPool) loadNodes() {
-	enc, err := pool.db.Get(pool.dbKey)
-	if err != nil {
-		return
-	}
-	var list []*poolEntry
-	err = rlp.DecodeBytes(enc, &list)
-	if err != nil {
-		log.Debug("Failed to decode node list", "err", err)
-		return
-	}
-	for _, e := range list {
-		log.Debug("Loaded server stats", "id", e.node.ID(), "fails", e.lastConnected.fails,
-			"conn", fmt.Sprintf("%v/%v", e.connectStats.avg, e.connectStats.weight),
-			"delay", fmt.Sprintf("%v/%v", time.Duration(e.delayStats.avg), e.delayStats.weight),
-			"response", fmt.Sprintf("%v/%v", time.Duration(e.responseStats.avg), e.responseStats.weight),
-			"timeout", fmt.Sprintf("%v/%v", e.timeoutStats.avg, e.timeoutStats.weight))
-		pool.entries[e.node.ID()] = e
-		if pool.trustedNodes[e.node.ID()] == nil {
-			pool.knownQueue.setLatest(e)
-			pool.knownSelect.Update((*knownEntry)(e))
-		}
-	}
-}
-
-// connectToTrustedNodes adds trusted server nodes as static trusted peers.
-//
-// Note: trusted nodes are not handled by the server pool logic, they are not
-// added to either the known or new selection pools. They are connected/reconnected
-// by p2p.Server whenever possible.
-func (pool *serverPool) connectToTrustedNodes() {
-	//connect to trusted nodes
-	for _, node := range pool.trustedNodes {
-		pool.server.AddTrustedPeer(node)
-		pool.server.AddPeer(node)
-		log.Debug("Added trusted node", "id", node.ID().String())
-	}
-}
-
-// parseTrustedNodes returns valid and parsed enodes
-func parseTrustedNodes(trustedNodes []string) map[enode.ID]*enode.Node {
-	nodes := make(map[enode.ID]*enode.Node)
-
-	for _, node := range trustedNodes {
-		node, err := enode.Parse(enode.ValidSchemes, node)
-		if err != nil {
-			log.Warn("Trusted node URL invalid", "enode", node, "err", err)
-			continue
-		}
-		nodes[node.ID()] = node
-	}
-	return nodes
-}
-
-// saveNodes saves known nodes and their statistics into the database. Nodes are
-// ordered from least to most recently connected.
-func (pool *serverPool) saveNodes() {
-	list := make([]*poolEntry, len(pool.knownQueue.queue))
-	for i := range list {
-		list[i] = pool.knownQueue.fetchOldest()
-	}
-	enc, err := rlp.EncodeToBytes(list)
-	if err == nil {
-		pool.db.Put(pool.dbKey, enc)
-	}
-}
-
-// removeEntry removes a pool entry when the entry count limit is reached.
-// Note that it is called by the new/known queues from which the entry has already
-// been removed so removing it from the queues is not necessary.
-func (pool *serverPool) removeEntry(entry *poolEntry) {
-	pool.newSelect.Remove((*discoveredEntry)(entry))
-	pool.knownSelect.Remove((*knownEntry)(entry))
-	entry.removed = true
-	delete(pool.entries, entry.node.ID())
-}
-
-// setRetryDial starts the timer which will enable dialing a certain node again
-func (pool *serverPool) setRetryDial(entry *poolEntry) {
-	delay := longRetryDelay
-	if entry.shortRetry > 0 {
-		entry.shortRetry--
-		delay = shortRetryDelay
-	}
-	delay += time.Duration(rand.Int63n(int64(delay) + 1))
-	entry.delayedRetry = true
-	go func() {
-		select {
-		case <-pool.closeCh:
-		case <-time.After(delay):
-			select {
-			case <-pool.closeCh:
-			case pool.enableRetry <- entry:
-			}
-		}
-	}()
-}
-
-// updateCheckDial is called when an entry can potentially be dialed again. It updates
-// its selection weights and checks if new dials can/should be made.
-func (pool *serverPool) updateCheckDial(entry *poolEntry) {
-	pool.newSelect.Update((*discoveredEntry)(entry))
-	pool.knownSelect.Update((*knownEntry)(entry))
-	pool.checkDial()
-}
-
-// checkDial checks if new dials can/should be made. It tries to select servers both
-// based on good statistics and recent discovery.
-func (pool *serverPool) checkDial() {
-	fillWithKnownSelects := !pool.fastDiscover
-	for pool.knownSelected < targetKnownSelect {
-		entry := pool.knownSelect.Choose()
-		if entry == nil {
-			fillWithKnownSelects = false
-			break
-		}
-		pool.dial((*poolEntry)(entry.(*knownEntry)), true)
-	}
-	for pool.knownSelected+pool.newSelected < targetServerCount {
-		entry := pool.newSelect.Choose()
-		if entry == nil {
-			break
-		}
-		pool.dial((*poolEntry)(entry.(*discoveredEntry)), false)
-	}
-	if fillWithKnownSelects {
-		// no more newly discovered nodes to select and since fast discover period
-		// is over, we probably won't find more in the near future so select more
-		// known entries if possible
-		for pool.knownSelected < targetServerCount {
-			entry := pool.knownSelect.Choose()
-			if entry == nil {
-				break
-			}
-			pool.dial((*poolEntry)(entry.(*knownEntry)), true)
-		}
-	}
-}
-
-// dial initiates a new connection
-func (pool *serverPool) dial(entry *poolEntry, knownSelected bool) {
-	if pool.server == nil || entry.state != psNotConnected {
-		return
-	}
-	entry.state = psDialed
-	entry.knownSelected = knownSelected
-	if knownSelected {
-		pool.knownSelected++
-	} else {
-		pool.newSelected++
-	}
-	addr := entry.addrSelect.Choose().(*poolEntryAddress)
-	log.Debug("Dialing new peer", "lesaddr", entry.node.ID().String()+"@"+addr.strKey(), "set", len(entry.addr), "known", knownSelected)
-	entry.dialed = addr
-	go func() {
-		pool.server.AddPeer(entry.node)
-		select {
-		case <-pool.closeCh:
-		case <-time.After(dialTimeout):
-			select {
-			case <-pool.closeCh:
-			case pool.timeout <- entry:
-			}
-		}
-	}()
-}
-
-// checkDialTimeout checks if the node is still in dialed state and if so, resets it
-// and adjusts connection statistics accordingly.
-func (pool *serverPool) checkDialTimeout(entry *poolEntry) {
-	if entry.state != psDialed {
-		return
-	}
-	log.Debug("Dial timeout", "lesaddr", entry.node.ID().String()+"@"+entry.dialed.strKey())
-	entry.state = psNotConnected
-	if entry.knownSelected {
-		pool.knownSelected--
-	} else {
-		pool.newSelected--
-	}
-	entry.connectStats.add(0, 1)
-	entry.dialed.fails++
-	pool.setRetryDial(entry)
-}
-
-const (
-	psNotConnected = iota
-	psDialed
-	psConnected
-	psRegistered
-)
-
-// poolEntry represents a server node and stores its current state and statistics.
-type poolEntry struct {
-	peer                  *serverPeer
-	pubkey                [64]byte // secp256k1 key of the node
-	addr                  map[string]*poolEntryAddress
-	node                  *enode.Node
-	lastConnected, dialed *poolEntryAddress
-	addrSelect            utils.WeightedRandomSelect
-
-	lastDiscovered                mclock.AbsTime
-	known, knownSelected, trusted bool
-	connectStats, delayStats      poolStats
-	responseStats, timeoutStats   poolStats
-	state                         int
-	regTime                       mclock.AbsTime
-	queueIdx                      int
-	removed                       bool
-
-	delayedRetry bool
-	shortRetry   int
-}
-
-// poolEntryEnc is the RLP encoding of poolEntry.
-type poolEntryEnc struct {
-	Pubkey                     []byte
-	IP                         net.IP
-	Port                       uint16
-	Fails                      uint
-	CStat, DStat, RStat, TStat poolStats
-}
-
-func (e *poolEntry) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, &poolEntryEnc{
-		Pubkey: encodePubkey64(e.node.Pubkey()),
-		IP:     e.lastConnected.ip,
-		Port:   e.lastConnected.port,
-		Fails:  e.lastConnected.fails,
-		CStat:  e.connectStats,
-		DStat:  e.delayStats,
-		RStat:  e.responseStats,
-		TStat:  e.timeoutStats,
+		n.lock.Lock()
+		n.dialCost.Add(dialCost, s.vt.StatsExpirer().LogOffset(s.clock.Now()))
+		n.lock.Unlock()
+		s.ns.UpdateState(node.ID(), s.stDialed, 0, time.Second*10)
+		return true
 	})
+	return s
 }
 
-func (e *poolEntry) DecodeRLP(s *rlp.Stream) error {
-	var entry poolEntryEnc
-	if err := s.Decode(&entry); err != nil {
-		return err
+// start starts the server pool. Note that NodeStateMachine should be started first.
+func (s *serverPool) start() {
+	for _, iter := range s.mixSources {
+		// add sources to mixer at startup because the mixer instantly tries to read them
+		// which should only happen after NodeStateMachine has been started
+		s.mixer.AddSource(iter)
 	}
-	pubkey, err := decodePubkey64(entry.Pubkey)
-	if err != nil {
-		return err
+	for _, id := range s.trusted {
+		s.ns.UpdateState(id, s.stAlwaysConnect, 0, 0)
 	}
-	addr := &poolEntryAddress{ip: entry.IP, port: entry.Port, fails: entry.Fails, lastSeen: mclock.Now()}
-	e.node = enode.NewV4(pubkey, entry.IP, int(entry.Port), int(entry.Port))
-	e.addr = make(map[string]*poolEntryAddress)
-	e.addr[addr.strKey()] = addr
-	e.addrSelect = *utils.NewWeightedRandomSelect()
-	e.addrSelect.Update(addr)
-	e.lastConnected = addr
-	e.connectStats = entry.CStat
-	e.delayStats = entry.DStat
-	e.responseStats = entry.RStat
-	e.timeoutStats = entry.TStat
-	e.shortRetry = shortRetryCnt
-	e.known = true
-	return nil
 }
 
-func encodePubkey64(pub *ecdsa.PublicKey) []byte {
-	return crypto.FromECDSAPub(pub)[1:]
+// stop stops the server pool
+func (s *serverPool) stop() {
+	s.dialIterator.Close()
 }
 
-func decodePubkey64(b []byte) (*ecdsa.PublicKey, error) {
-	return crypto.UnmarshalPubkey(append([]byte{0x04}, b...))
+// registerPeer implements serverPeerSubscriber
+func (s *serverPool) registerPeer(p *serverPeer) {
+	s.ns.UpdateState(p.ID(), s.stConnected, s.stDialed, 0)
+	p.setValueTracker(s.vt, s.vt.Register(p.ID()))
+	p.updateVtParams()
 }
 
-// discoveredEntry implements wrsItem
-type discoveredEntry poolEntry
+// unregisterPeer implements serverPeerSubscriber
+func (s *serverPool) unregisterPeer(p *serverPeer) {
+	if s.nodeWeight(p.ID(), true) >= nodeWeightThreshold {
+		s.ns.UpdateState(p.ID(), s.stHasValue, 0, 0)
+	}
+	s.ns.UpdateState(p.ID(), s.stRedialWait, s.stConnected, time.Second*10)
+	s.vt.Unregister(p.ID())
+	p.setValueTracker(nil, nil)
+}
 
-// Weight calculates random selection weight for newly discovered entries
-func (e *discoveredEntry) Weight() int64 {
-	if e.state != psNotConnected || e.delayedRetry {
+// getTimeout calculates the current recommended timeout. This value is used by
+// the client as a "soft timeout" value. It also affects the service value calculation
+// of individual nodes.
+func (s *serverPool) getTimeout() time.Duration {
+	now := s.clock.Now()
+	s.timeoutLock.RLock()
+	timeout := s.timeout
+	refreshed := s.timeoutRefreshed
+	s.timeoutLock.RUnlock()
+	if refreshed != 0 && time.Duration(now-refreshed) < timeoutRefresh {
+		return timeout
+	}
+	rts := s.vt.RtStats()
+	rts.Add(time.Second*2, 10, s.vt.StatsExpFactor())
+	timeout = minTimeout
+	if t := rts.Timeout(0.1); t > timeout {
+		timeout = t
+	}
+	if t := rts.Timeout(0.5) * 2; t > timeout {
+		timeout = t
+	}
+	s.timeoutLock.Lock()
+	if s.timeout != timeout {
+		s.timeout = timeout
+		s.timeWeights = lpc.TimeoutWeights(timeout)
+	}
+	s.timeoutRefreshed = now
+	s.timeoutLock.Unlock()
+	return timeout
+}
+
+// nodeWeight calculates the selection weight of an individual node
+func (s *serverPool) nodeWeight(id enode.ID, forceRecalc bool) uint64 {
+	nn := s.ns.GetField(id, s.nodeHistoryFieldId)
+	n, ok := nn.(*nodeHistory)
+	if !ok {
 		return 0
 	}
-	t := time.Duration(mclock.Now() - e.lastDiscovered)
-	if t <= discoverExpireStart {
-		return 1000000000
+	if n == nil {
+		n = &nodeHistory{}
+		s.ns.SetField(id, s.nodeHistoryFieldId, n)
 	}
-	return int64(1000000000 * math.Exp(-float64(t-discoverExpireStart)/float64(discoverExpireConst)))
-}
-
-// knownEntry implements wrsItem
-type knownEntry poolEntry
-
-// Weight calculates random selection weight for known entries
-func (e *knownEntry) Weight() int64 {
-	if e.state != psNotConnected || !e.known || e.delayedRetry {
+	nvt := s.vt.GetNode(id)
+	if nvt == nil {
 		return 0
 	}
-	return int64(1000000000 * e.connectStats.recentAvg() * math.Exp(-float64(e.lastConnected.fails)*failDropLn-e.responseStats.recentAvg()/float64(responseScoreTC)-e.delayStats.recentAvg()/float64(delayScoreTC)) * math.Pow(1-e.timeoutStats.recentAvg(), timeoutPow))
-}
-
-// poolEntryAddress is a separate object because currently it is necessary to remember
-// multiple potential network addresses for a pool entry. This will be removed after
-// the final implementation of v5 discovery which will retrieve signed and serial
-// numbered advertisements, making it clear which IP/port is the latest one.
-type poolEntryAddress struct {
-	ip       net.IP
-	port     uint16
-	lastSeen mclock.AbsTime // last time it was discovered, connected or loaded from db
-	fails    uint           // connection failures since last successful connection (persistent)
-}
-
-func (a *poolEntryAddress) Weight() int64 {
-	t := time.Duration(mclock.Now() - a.lastSeen)
-	return int64(1000000*math.Exp(-float64(t)/float64(discoverExpireConst)-float64(a.fails)*addrFailDropLn)) + 1
-}
-
-func (a *poolEntryAddress) strKey() string {
-	return a.ip.String() + ":" + strconv.Itoa(int(a.port))
-}
-
-// poolStats implement statistics for a certain quantity with a long term average
-// and a short term value which is adjusted exponentially with a factor of
-// pstatRecentAdjust with each update and also returned exponentially to the
-// average with the time constant pstatReturnToMeanTC
-type poolStats struct {
-	sum, weight, avg, recent float64
-	lastRecalc               mclock.AbsTime
-}
-
-// init initializes stats with a long term sum/update count pair retrieved from the database
-func (s *poolStats) init(sum, weight float64) {
-	s.sum = sum
-	s.weight = weight
-	var avg float64
-	if weight > 0 {
-		avg = s.sum / weight
+	div := n.dialCost.Value(s.vt.StatsExpirer().LogOffset(s.clock.Now()))
+	if div < dialCost {
+		div = dialCost
 	}
-	s.avg = avg
-	s.recent = avg
-	s.lastRecalc = mclock.Now()
-}
+	timeout := s.getTimeout()
 
-// recalc recalculates recent value return-to-mean and long term average
-func (s *poolStats) recalc() {
-	now := mclock.Now()
-	s.recent = s.avg + (s.recent-s.avg)*math.Exp(-float64(now-s.lastRecalc)/float64(pstatReturnToMeanTC))
-	if s.sum == 0 {
-		s.avg = 0
-	} else {
-		if s.sum > s.weight*1e30 {
-			s.avg = 1e30
-		} else {
-			s.avg = s.sum / s.weight
-		}
+	n.lock.Lock()
+	defer n.lock.Unlock()
+
+	if forceRecalc || timeout < n.lastTimeout-timeoutChangeThreshold || timeout > n.lastTimeout+timeoutChangeThreshold {
+		s.timeoutLock.RLock()
+		timeWeights := s.timeWeights
+		s.timeoutLock.RUnlock()
+		n.totalValue = s.vt.TotalServiceValue(nvt, timeWeights)
+		n.lastTimeout = timeout
 	}
-	s.lastRecalc = now
+	return uint64(n.totalValue * nodeWeightMul / float64(div))
 }
 
-// add updates the stats with a new value
-func (s *poolStats) add(value, weight float64) {
-	s.weight += weight
-	s.sum += value * weight
-	s.recalc()
-}
-
-// recentAvg returns the short-term adjusted average
-func (s *poolStats) recentAvg() float64 {
-	s.recalc()
-	return s.recent
-}
-
-func (s *poolStats) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, []interface{}{math.Float64bits(s.sum), math.Float64bits(s.weight)})
-}
-
-func (s *poolStats) DecodeRLP(st *rlp.Stream) error {
-	var stats struct {
-		SumUint, WeightUint uint64
+// knownSelectWeight is the selection weight callback function. It also takes care of
+// removing nodes from the valuable set if their value has been expired.
+func (s *serverPool) knownSelectWeight(i interface{}) uint64 {
+	id := i.(enode.ID)
+	wt := s.nodeWeight(id, false)
+	if wt < nodeWeightThreshold {
+		go s.ns.UpdateState(id, 0, s.stHasValue, 0)
+		return 0
 	}
-	if err := st.Decode(&stats); err != nil {
-		return err
-	}
-	s.init(math.Float64frombits(stats.SumUint), math.Float64frombits(stats.WeightUint))
-	return nil
-}
-
-// poolEntryQueue keeps track of its least recently accessed entries and removes
-// them when the number of entries reaches the limit
-type poolEntryQueue struct {
-	queue                  map[int]*poolEntry // known nodes indexed by their latest lastConnCnt value
-	newPtr, oldPtr, maxCnt int
-	removeFromPool         func(*poolEntry)
-}
-
-// newPoolEntryQueue returns a new poolEntryQueue
-func newPoolEntryQueue(maxCnt int, removeFromPool func(*poolEntry)) poolEntryQueue {
-	return poolEntryQueue{queue: make(map[int]*poolEntry), maxCnt: maxCnt, removeFromPool: removeFromPool}
-}
-
-// fetchOldest returns and removes the least recently accessed entry
-func (q *poolEntryQueue) fetchOldest() *poolEntry {
-	if len(q.queue) == 0 {
-		return nil
-	}
-	for {
-		if e := q.queue[q.oldPtr]; e != nil {
-			delete(q.queue, q.oldPtr)
-			q.oldPtr++
-			return e
-		}
-		q.oldPtr++
-	}
-}
-
-// remove removes an entry from the queue
-func (q *poolEntryQueue) remove(entry *poolEntry) {
-	if q.queue[entry.queueIdx] == entry {
-		delete(q.queue, entry.queueIdx)
-	}
-}
-
-// setLatest adds or updates a recently accessed entry. It also checks if an old entry
-// needs to be removed and removes it from the parent pool too with a callback function.
-func (q *poolEntryQueue) setLatest(entry *poolEntry) {
-	if q.queue[entry.queueIdx] == entry {
-		delete(q.queue, entry.queueIdx)
-	} else {
-		if len(q.queue) == q.maxCnt {
-			e := q.fetchOldest()
-			q.remove(e)
-			q.removeFromPool(e)
-		}
-	}
-	entry.queueIdx = q.newPtr
-	q.queue[entry.queueIdx] = entry
-	q.newPtr++
+	return wt
 }

--- a/les/serverpool_test.go
+++ b/les/serverpool_test.go
@@ -1,0 +1,259 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package les
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/ethdb/memorydb"
+	lpc "github.com/ethereum/go-ethereum/les/lespay/client"
+	"github.com/ethereum/go-ethereum/les/utils"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
+)
+
+const (
+	testNodes  = 1000
+	testTarget = 5
+)
+
+func testNodeID(i int) enode.ID {
+	return enode.ID{42, byte(i % 256), byte(i / 256)}
+}
+
+func testNodeIndex(id enode.ID) int {
+	if id[0] != 42 {
+		return -1
+	}
+	return int(id[1]) + int(id[2])*256
+}
+
+type serverPoolTest struct {
+	db        ethdb.KeyValueStore
+	clock     *mclock.Simulated
+	ns        *utils.NodeStateMachine
+	vt        *lpc.ValueTracker
+	sp        *serverPool
+	input     enode.Iterator
+	testNodes []spTestNode
+	trusted   []string
+
+	cycle, conn, servedConn  int
+	serviceCycles, dialCount int
+	disconnect               map[int][]int
+}
+
+type spTestNode struct {
+	connectCycles, waitCycles int
+	nextConnCycle, totalConn  int
+	connected, service        bool
+	peer                      *serverPeer
+}
+
+func newServerPoolTest() *serverPoolTest {
+	nodes := make([]*enode.Node, testNodes)
+	for i := range nodes {
+		nodes[i] = enode.SignNull(&enr.Record{}, testNodeID(i))
+	}
+	return &serverPoolTest{
+		clock:     &mclock.Simulated{},
+		db:        memorydb.New(),
+		input:     enode.CycleNodes(nodes),
+		testNodes: make([]spTestNode, testNodes),
+	}
+}
+
+func (s *serverPoolTest) addTrusted(i int) {
+	s.trusted = append(s.trusted, enode.SignNull(&enr.Record{}, testNodeID(i)).String())
+}
+
+func (s *serverPoolTest) start() {
+	s.ns = utils.NewNodeStateMachine(s.db, []byte("serverpool:"), s.clock)
+	s.vt = lpc.NewValueTracker(s.db, s.clock, requestList, time.Minute, 1/float64(time.Hour), 1/float64(time.Hour*100), 1/float64(time.Hour*1000))
+	s.sp = newServerPool(s.ns, s.vt, s.input, s.clock, s.trusted, true)
+	s.disconnect = make(map[int][]int)
+	s.ns.Start()
+	s.sp.start()
+}
+
+func (s *serverPoolTest) stop() {
+	s.ns.Stop()
+	s.sp.stop()
+	s.vt.Stop()
+	for i := range s.testNodes {
+		n := &s.testNodes[i]
+		if n.connected {
+			n.totalConn += s.cycle
+		}
+		n.connected = false
+		n.peer = nil
+		n.nextConnCycle = 0
+	}
+	s.conn, s.servedConn = 0, 0
+}
+
+func (s *serverPoolTest) run(count int) {
+	for ; count > 0; count-- {
+		if dcList := s.disconnect[s.cycle]; dcList != nil {
+			for _, idx := range dcList {
+				n := &s.testNodes[idx]
+				s.sp.unregisterPeer(n.peer)
+				n.totalConn += s.cycle
+				n.connected = false
+				n.peer = nil
+				s.conn--
+				if n.service {
+					s.servedConn--
+				}
+				n.nextConnCycle = s.cycle + n.waitCycles
+			}
+			delete(s.disconnect, s.cycle)
+		}
+		if s.conn < testTarget {
+			s.dialCount++
+			s.sp.dialIterator.Next()
+			dial := s.sp.dialIterator.Node()
+			id := dial.ID()
+			idx := testNodeIndex(id)
+			n := &s.testNodes[idx]
+			if !n.connected && n.connectCycles != 0 && s.cycle >= n.nextConnCycle {
+				s.conn++
+				if n.service {
+					s.servedConn++
+				}
+				n.totalConn -= s.cycle
+				n.connected = true
+				dc := s.cycle + n.connectCycles
+				s.disconnect[dc] = append(s.disconnect[dc], idx)
+				n.peer = &serverPeer{peerCommons: peerCommons{Peer: p2p.NewPeer(id, "", nil)}}
+				s.sp.registerPeer(n.peer)
+				if n.service {
+					s.vt.Served(s.vt.GetNode(id), []lpc.ServedRequest{{ReqType: 0, Amount: 100}}, 0)
+				}
+			}
+		}
+		s.serviceCycles += s.servedConn
+		s.clock.Run(time.Second)
+		s.cycle++
+	}
+}
+
+func (s *serverPoolTest) setNodes(count, conn, wait int, service, trusted bool) (res []int) {
+	for ; count > 0; count-- {
+		idx := rand.Intn(testNodes)
+		for s.testNodes[idx].connectCycles != 0 || s.testNodes[idx].connected {
+			idx = rand.Intn(testNodes)
+		}
+		res = append(res, idx)
+		s.testNodes[idx] = spTestNode{
+			connectCycles: conn,
+			waitCycles:    wait,
+			service:       service,
+		}
+		if trusted {
+			s.addTrusted(idx)
+		}
+	}
+	return
+}
+
+func (s *serverPoolTest) resetNodes() {
+	for i, n := range s.testNodes {
+		if n.connected {
+			n.totalConn += s.cycle
+			s.sp.unregisterPeer(n.peer)
+		}
+		s.testNodes[i] = spTestNode{totalConn: n.totalConn}
+	}
+	s.conn, s.servedConn = 0, 0
+	s.disconnect = make(map[int][]int)
+	s.trusted = nil
+}
+
+func (s *serverPoolTest) checkNodes(t *testing.T, nodes []int, minTotal, maxTotal int) {
+	var sum int
+	for _, idx := range nodes {
+		n := &s.testNodes[idx]
+		if n.connected {
+			n.totalConn += s.cycle
+		}
+		sum += n.totalConn
+		n.totalConn = 0
+		if n.connected {
+			n.totalConn -= s.cycle
+		}
+	}
+	if sum < minTotal || sum > maxTotal {
+		t.Errorf("Total connection amount %d outside expected range %d to %d", sum, minTotal, maxTotal)
+	}
+}
+
+func TestServerPool(t *testing.T) {
+	s := newServerPoolTest()
+	nodes := s.setNodes(20, 200, 200, true, false)
+	s.setNodes(20, 20, 20, false, false)
+	s.start()
+	s.run(10000)
+	s.stop()
+	s.checkNodes(t, nodes, 40000, 50000)
+}
+
+func TestServerPoolChangedNodes(t *testing.T) {
+	s := newServerPoolTest()
+	nodes := s.setNodes(20, 200, 200, true, false)
+	s.setNodes(20, 20, 20, false, false)
+	s.start()
+	s.run(10000)
+	s.checkNodes(t, nodes, 40000, 50000)
+	for i := 0; i < 3; i++ {
+		s.resetNodes()
+		nodes := s.setNodes(20, 200, 200, true, false)
+		s.setNodes(20, 20, 20, false, false)
+		s.run(10000)
+		s.checkNodes(t, nodes, 40000, 50000)
+	}
+	s.stop()
+}
+
+func TestServerPoolRestartNoDiscovery(t *testing.T) {
+	s := newServerPoolTest()
+	nodes := s.setNodes(20, 200, 200, true, false)
+	s.setNodes(20, 20, 20, false, false)
+	s.start()
+	s.run(10000)
+	s.stop()
+	s.checkNodes(t, nodes, 40000, 50000)
+	s.input = nil
+	s.start()
+	s.run(10000)
+	s.stop()
+	s.checkNodes(t, nodes, 40000, 50000)
+}
+
+func TestServerPoolTrustedNoDiscovery(t *testing.T) {
+	s := newServerPoolTest()
+	trusted := s.setNodes(2, 300, 100, false, true)
+	s.start()
+	s.run(10000)
+	s.stop()
+	s.checkNodes(t, trusted, 13000, 16000)
+}

--- a/les/test_helper.go
+++ b/les/test_helper.go
@@ -508,7 +508,8 @@ func newClientServerEnv(t *testing.T, blocks int, protocol int, callback indexer
 		clock = &mclock.Simulated{}
 	}
 	dist := newRequestDistributor(speers, clock)
-	rm := newRetrieveManager(speers, dist, nil)
+	rm := newRetrieveManager(speers, dist)
+	rm.setTimeoutCallback(func() time.Duration { return time.Millisecond * 500 })
 	odr := NewLesOdr(cdb, light.TestClientIndexerConfig, rm)
 
 	sindexers := testIndexers(sdb, nil, light.TestServerIndexerConfig)

--- a/les/utils/nodestate.go
+++ b/les/utils/nodestate.go
@@ -1,0 +1,923 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+	"unsafe"
+
+	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+type (
+	// NodeStateMachine connects different system components operating on subsets of
+	// network nodes. Node states are represented by 64 bit vectors with each bit assigned
+	// to a state flag. Each state flag has a descriptor structure and the mapping is
+	// created automatically. It is possible to subscribe to subsets of state flags and
+	// receive a callback if one of the nodes has a relevant state flag changed.
+	// Callbacks can also modify further flags of the same node or other nodes. State
+	// updates only return after all immediate effects throughout the system have happened
+	// (deadlocks should be avoided by design of the implemented state logic). The caller
+	// can also add timeouts assigned to a certain node and a subset of state flags.
+	// If the timeout elapses, the flags are reset. If all relevant flags are reset then
+	// the timer is dropped. The state flags and the associated timers are persisted in
+	// the database if the flag descriptor enables saving.
+	//
+	// Extra node fields can also be registered so system components can also store more
+	// complex state for each node that is relevant to them, without creating a custom
+	// peer set. Fields can be shared across multiple components if they all know the
+	// field ID. Fields are also assigned to a set of state flags and the contents of
+	// each field is only retained for a certain node as long as at least one of these
+	// flags is set (meaning that the node is still interesting to the component(s) which
+	// are interested in the given field). Persistent fields should have an encoder and
+	// a decoder function.
+	NodeStateMachine struct {
+		started, stopped                    bool
+		lock                                sync.Mutex
+		clock                               mclock.Clock
+		db                                  ethdb.KeyValueStore
+		dbMappingKey, dbNodeKey, dbClockKey []byte
+		mappings                            []nsMapping
+		currentMapping                      int
+		nodes                               map[enode.ID]*nodeInfo
+		quit                                chan chan struct{}
+		offlineCallbackList                 []offlineCallback
+
+		// Registered state flags or fields. Modifications are allowed
+		// only when the node state machine has not been initialized.
+		nodeStates                      map[*NodeStateFlag]int
+		nodeStateNameMap                map[string]int
+		nodeFields                      []*NodeStateField
+		nodeFieldMasks                  []NodeStateBitMask
+		nodeFieldMap                    map[*NodeStateField]int
+		nodeFieldNameMap                map[string]int
+		stateCount                      int
+		stateLimit                      int
+		saveImmediately, saveAtShutdown NodeStateBitMask
+
+		// Installed callbacks. Modifications are allowed only when the
+		// node state machine has not been initialized.
+		stateSubs []nodeStateSub
+
+		// clock offset is persisted in order to correctly interpret saved timer expiration
+		clockOffset, clockPersisted mclock.AbsTime
+		clockStart                  uint64
+
+		// Testing hooks, only for testing purposes.
+		saveNodeHook func(*nodeInfo)
+	}
+
+	// NodeStateFlag describes a node state flag. Each registered instance is automatically
+	// mapped to a bit of the 64 bit node states.
+	// If saveImmediately is true then the node is saved each time the flag is switched on
+	// or off. If saveAtShutdown is true then the node is saved when state machine is shutdown.
+	NodeStateFlag struct {
+		name                            string
+		saveImmediately, saveAtShutdown bool
+	}
+
+	// NodeStateField describes an optional node field of the given type. The contents
+	// of the field are only retained for each node as long as at least one of the
+	// specified flags is set. If all relevant flags are reset then the field is removed
+	// after all callbacks of the state change are processed.
+	NodeStateField struct {
+		name   string
+		ftype  reflect.Type
+		flags  []*NodeStateFlag
+		encode func(interface{}) ([]byte, error)
+		decode func([]byte) (interface{}, error)
+	}
+
+	// nsMapping describes an index mapping of node state flags and fields. Mapping is
+	// determined during startup, before loading node data from the database. The used
+	// mapping is saved for each node and is converted upon loading if it has changed
+	// since the last time it was saved.
+	nsMapping struct {
+		States, Fields []string
+	}
+
+	// NodeStateBitMask describes a node state or state mask. It represents a subset
+	// of node flags with each bit assigned to a flag index (LSB represents flag 0).
+	NodeStateBitMask uint64
+
+	// NodeStateCallback is a subscription callback which is called when one of the
+	// state flags that is included in the subscription state mask is changed.
+	// Note: oldState and newState are also masked with the subscription mask so only
+	// the relevant bits are included.
+	NodeStateCallback func(id enode.ID, oldState, newState NodeStateBitMask)
+
+	// nodeInfo contains node state, fields and state timeouts
+	nodeInfo struct {
+		state          NodeStateBitMask
+		timeouts       []*nodeStateTimeout
+		fields         []interface{}
+		fieldGcCounter int
+		db, dirty      bool
+	}
+
+	nodeInfoEnc struct {
+		Mapping  uint
+		State    NodeStateBitMask
+		Timeouts []nodeStateTimeoutEnc
+		Fields   [][]byte
+	}
+
+	nodeStateSub struct {
+		mask     NodeStateBitMask
+		callback NodeStateCallback
+	}
+
+	nodeStateTimeout struct {
+		id    enode.ID
+		at    mclock.AbsTime
+		timer mclock.Timer
+		mask  NodeStateBitMask
+	}
+
+	nodeStateTimeoutEnc struct {
+		At   uint64
+		Mask NodeStateBitMask
+	}
+
+	offlineCallback struct {
+		id    enode.ID
+		state NodeStateBitMask
+	}
+)
+
+var (
+	errAlreadyStarted = errors.New("state machine already started")
+	errNotStarted     = errors.New("state machine not started yet")
+	errStateOverflow  = errors.New("registered state flag exceeds the limit")
+	errNameCollision  = errors.New("state flag or node field name collision")
+	errOutOfBound     = errors.New("out of bound")
+	errInvalidField   = errors.New("invalid field type")
+
+	OfflineFlag = NewNodeStateFlag("offline", false, false)
+)
+
+// OfflineState is a special state that is assumed to be set before a node is loaded from
+// the database and after it is shut down.
+const OfflineState = NodeStateBitMask(1)
+
+// NewNodeStateMachine creates a new node state machine.
+// If db is not nil then the node states, fields and active timeouts are persisted.
+// Persistence can be enabled or disabled for each state flag.
+func NewNodeStateMachine(db ethdb.KeyValueStore, dbKey []byte, clock mclock.Clock) *NodeStateMachine {
+	ns := &NodeStateMachine{
+		db:               db,
+		dbMappingKey:     append(dbKey, []byte("mapping:")...),
+		dbNodeKey:        append(dbKey, []byte("node:")...),
+		dbClockKey:       append(dbKey, []byte("clock:")...),
+		clock:            clock,
+		nodes:            make(map[enode.ID]*nodeInfo),
+		nodeStates:       make(map[*NodeStateFlag]int),
+		nodeStateNameMap: make(map[string]int),
+		nodeFieldMap:     make(map[*NodeStateField]int),
+		nodeFieldNameMap: make(map[string]int),
+		stateLimit:       8 * int(unsafe.Sizeof(NodeStateBitMask(0))),
+		quit:             make(chan chan struct{}),
+	}
+	// init flag is always mapped to index 0 (OfflineState bit mask)
+	ns.RegisterState(OfflineFlag)
+	return ns
+}
+
+// NewNodeStateFlag creates a new node state flag. Mapping happens when it is first passed
+// to NodeStateMachine.RegisterState
+func NewNodeStateFlag(name string, saveImmediately, saveAtShutdown bool) *NodeStateFlag {
+	return &NodeStateFlag{
+		name:            name,
+		saveImmediately: saveImmediately,
+		saveAtShutdown:  saveAtShutdown,
+	}
+}
+
+// NewNodeStateField creates a new node state field. Mapping happens when it is first passed
+// to NodeStateMachine.RegisterField
+func NewNodeStateField(name string, ftype reflect.Type, flags []*NodeStateFlag, encode func(interface{}) ([]byte, error), decode func([]byte) (interface{}, error)) *NodeStateField {
+	return &NodeStateField{
+		name:   name,
+		ftype:  ftype,
+		flags:  flags,
+		encode: encode,
+		decode: decode,
+	}
+}
+
+// AddStateSub adds a node state subscription. The callback is called while the state
+// machine mutex is not held and it is allowed to make further state updates. All immediate
+// changes throughout the system are processed in the same thread/goroutine. It is the
+// responsibility of the implemented state logic to avoid deadlocks caused by the callbacks,
+// infinite toggling of flags or hazardous/non-deterministic state changes.
+// State subscriptions should be installed before loading the node database or making the
+// first state update.
+func (ns *NodeStateMachine) AddStateSub(mask NodeStateBitMask, callback NodeStateCallback) error {
+	ns.lock.Lock()
+	defer ns.lock.Unlock()
+
+	if ns.started {
+		return errAlreadyStarted
+	}
+	ns.stateSubs = append(ns.stateSubs, nodeStateSub{mask, callback})
+	return nil
+}
+
+// newNode creates a new nodeInfo
+func (ns *NodeStateMachine) newNode() *nodeInfo {
+	return &nodeInfo{fields: make([]interface{}, len(ns.nodeFields))}
+}
+
+// checkStarted checks whether the state machine has already been started and panics otherwise.
+func (ns *NodeStateMachine) checkStarted() {
+	if !ns.started {
+		panic(errNotStarted)
+	}
+}
+
+// Start starts the state machine, enabling state and field operations and disabling
+// further setup operations (flag and field registrations).
+func (ns *NodeStateMachine) Start() {
+	ns.lock.Lock()
+	if ns.started {
+		panic(errAlreadyStarted)
+	}
+	ns.started = true
+	if ns.db != nil {
+		ns.loadFromDb()
+		go func() {
+			for {
+				select {
+				case <-ns.clock.After(time.Minute * 10):
+					ns.lock.Lock()
+					ns.persistClock()
+					ns.lock.Unlock()
+				case q := <-ns.quit:
+					close(q)
+					return
+				}
+			}
+		}()
+	} else {
+		ns.clockOffset = -ns.clock.Now()
+	}
+	ns.lock.Unlock()
+	ns.offlineCallbacks(true)
+}
+
+// Stop stops the state machine and saves its state if a database was supplied
+func (ns *NodeStateMachine) Stop() {
+	ns.lock.Lock()
+	for id, node := range ns.nodes {
+		ns.offlineCallbackList = append(ns.offlineCallbackList, offlineCallback{id, node.state})
+	}
+	ns.stopped = true
+	if ns.db != nil {
+		ns.saveToDb()
+		ns.lock.Unlock()
+		quit := make(chan struct{})
+		ns.quit <- quit
+		<-quit
+	} else {
+		ns.lock.Unlock()
+	}
+	ns.offlineCallbacks(false)
+}
+
+// loadFromDb loads persisted node states from the database
+func (ns *NodeStateMachine) loadFromDb() {
+	var clockStart uint64
+	if enc, err := ns.db.Get(ns.dbClockKey); err == nil {
+		if err := rlp.DecodeBytes(enc, &clockStart); err != nil {
+			log.Error("Failed to decode persistent clock", "error", err)
+			return
+		}
+	}
+	now := ns.clock.Now()
+	ns.clockOffset = mclock.AbsTime(clockStart) - now
+	ns.clockPersisted = now
+
+	if enc, err := ns.db.Get(ns.dbMappingKey); err == nil {
+		if err := rlp.DecodeBytes(enc, &ns.mappings); err != nil {
+			log.Error("Failed to decode scheme", "error", err)
+			return
+		}
+	}
+	mapping := nsMapping{
+		States: make([]string, len(ns.nodeStates)),
+		Fields: make([]string, len(ns.nodeFields)),
+	}
+	for flag, index := range ns.nodeStates {
+		mapping.States[index] = flag.name
+	}
+	for index, field := range ns.nodeFields {
+		mapping.Fields[index] = field.name
+	}
+	ns.currentMapping = -1
+loop:
+	for i, m := range ns.mappings {
+		if len(m.States) != len(mapping.States) {
+			continue loop
+		}
+		if len(m.Fields) != len(mapping.Fields) {
+			continue loop
+		}
+		for j, s := range mapping.States {
+			if m.States[j] != s {
+				continue loop
+			}
+		}
+		for j, s := range mapping.Fields {
+			if m.Fields[j] != s {
+				continue loop
+			}
+		}
+		ns.currentMapping = i
+		break
+	}
+	if ns.currentMapping == -1 {
+		ns.currentMapping = len(ns.mappings)
+		ns.mappings = append(ns.mappings, mapping)
+
+		// Scheme should be persisted properly, otherwise
+		// all persisted data can't be resolved next time.
+		enc, err := rlp.EncodeToBytes(ns.mappings)
+		if err != nil {
+			panic("Failed to encode scheme")
+		}
+		if err := ns.db.Put(ns.dbMappingKey, enc); err != nil {
+			panic("Failed to save scheme")
+		}
+	}
+
+	it := ns.db.NewIteratorWithPrefix(ns.dbNodeKey)
+	for it.Next() {
+		var id enode.ID
+		if len(it.Key()) != len(ns.dbNodeKey)+len(id) {
+			log.Error("Node state db entry with invalid length", "found", len(it.Key()), "expected", len(ns.dbNodeKey)+len(id))
+			continue
+		}
+		copy(id[:], it.Key()[len(ns.dbNodeKey):])
+		ns.decodeNode(id, it.Value(), now)
+	}
+}
+
+// persistClock stores the current cumulative time in the database
+func (ns *NodeStateMachine) persistClock() {
+	now := ns.clock.Now()
+	if time.Duration(now-ns.clockPersisted) < time.Second*10 {
+		return
+	}
+
+	pclock := uint64(now + ns.clockOffset)
+	enc, err := rlp.EncodeToBytes(&pclock)
+	if err != nil {
+		log.Error("Failed to encode persistent clock", "error", err)
+		return
+	}
+	if err := ns.db.Put(ns.dbClockKey, enc); err != nil {
+		log.Error("Failed to save persistent clock", "error", err)
+		return
+	}
+	ns.clockPersisted = now
+}
+
+// decodeNode decodes a node database entry and adds it to the node set if successful
+func (ns *NodeStateMachine) decodeNode(id enode.ID, data []byte, now mclock.AbsTime) {
+	var enc nodeInfoEnc
+	if err := rlp.DecodeBytes(data, &enc); err != nil {
+		log.Error("Failed to decode node info", "id", id, "error", err)
+		return
+	}
+	node := ns.newNode()
+	node.db = true
+
+	if int(enc.Mapping) >= len(ns.mappings) {
+		log.Error("Unknown scheme", "id", id, "index", enc.Mapping, "len", len(ns.mappings))
+		return
+	}
+	encMapping := ns.mappings[int(enc.Mapping)]
+	if len(enc.Fields) != len(encMapping.Fields) {
+		log.Error("Invalid node field count", "id", id, "stored", len(enc.Fields), "mapping", len(encMapping.Fields))
+		return
+	}
+	// convertMask converts a old format state/mask to the latest version.
+	convertMask := func(schemeID int, scheme []string, state NodeStateBitMask) (NodeStateBitMask, bool) {
+		if schemeID == ns.currentMapping {
+			return state, true // Nothing need to be changed
+		}
+		var converted NodeStateBitMask
+		for i, name := range scheme {
+			if (state & (NodeStateBitMask(1) << i)) != 0 {
+				if index, ok := ns.nodeStateNameMap[name]; ok {
+					converted |= NodeStateBitMask(1) << index
+				} else {
+					log.Error("Unknown state flag", "name", name)
+					return NodeStateBitMask(0), false // unknown flag
+				}
+			}
+		}
+		return converted, true
+	}
+	// Resolve persisted node fields
+	for i, encField := range enc.Fields {
+		if len(encField) == 0 {
+			continue
+		}
+		index := i
+		if int(enc.Mapping) != ns.currentMapping {
+			name := encMapping.Fields[i]
+			var ok bool
+			if index, ok = ns.nodeFieldNameMap[name]; !ok {
+				log.Error("Unknown node field", "id", id, "field name", name)
+				return
+			}
+		}
+		if decode := ns.nodeFields[index].decode; decode != nil {
+			if field, err := decode(encField); err == nil {
+				node.fields[index] = field
+			} else {
+				log.Error("Failed to decode node field", "id", id, "field name", ns.nodeFields[index].name, "error", err)
+				return
+			}
+		} else {
+			log.Error("Cannot decode node field", "id", id, "field name", ns.nodeFields[index].name)
+			return
+		}
+	}
+	// Resolve node state
+	state, success := convertMask(int(enc.Mapping), encMapping.States, enc.State)
+	if !success {
+		return
+	}
+	var masks []NodeStateBitMask
+	for _, et := range enc.Timeouts {
+		if mask, success := convertMask(int(enc.Mapping), encMapping.States, et.Mask); success {
+			masks = append(masks, mask)
+		} else {
+			return
+		}
+	}
+	// It's a compatible node record, add it to set.
+	ns.nodes[id] = node
+	node.state = state
+	ns.offlineCallbackList = append(ns.offlineCallbackList, offlineCallback{id, state})
+	for index, et := range enc.Timeouts {
+		dt := time.Duration(et.At - uint64(now+ns.clockOffset))
+		if dt < 0 {
+			dt = 0
+		}
+		ns.addTimeout(id, masks[index], dt)
+	}
+	log.Debug("Loaded node state", "id", id, "state", ns.stateToString(enc.State))
+}
+
+// saveNode saves the given node info to the database
+func (ns *NodeStateMachine) saveNode(id enode.ID, node *nodeInfo) error {
+	if ns.db == nil {
+		return nil
+	}
+	saveStates := ns.saveImmediately | ns.saveAtShutdown
+	newState := node.state & saveStates
+	if newState == 0 {
+		if node.db {
+			node.db = false
+			ns.deleteNode(id)
+		}
+		node.dirty = false
+		return nil
+	}
+
+	enc := nodeInfoEnc{
+		Mapping: uint(ns.currentMapping),
+		State:   newState,
+		Fields:  make([][]byte, len(ns.nodeFields)),
+	}
+	log.Debug("Saved node state", "id", id, "state", ns.stateToString(enc.State))
+	for _, t := range node.timeouts {
+		if mask := t.mask & saveStates; mask != 0 {
+			enc.Timeouts = append(enc.Timeouts, nodeStateTimeoutEnc{
+				At:   uint64(t.at + ns.clockOffset),
+				Mask: mask,
+			})
+		}
+	}
+	for i, f := range node.fields {
+		if f == nil {
+			continue
+		}
+		encode := ns.nodeFields[i].encode
+		if encode == nil {
+			continue
+		}
+		blob, err := encode(f)
+		if err != nil {
+			return err
+		}
+		enc.Fields[i] = blob
+	}
+	data, err := rlp.EncodeToBytes(&enc)
+	if err != nil {
+		return err
+	}
+	if err := ns.db.Put(append(ns.dbNodeKey, id[:]...), data); err != nil {
+		return err
+	}
+	node.dirty, node.db = false, true
+	ns.persistClock()
+
+	if ns.saveNodeHook != nil {
+		ns.saveNodeHook(node)
+	}
+	return nil
+}
+
+// deleteNode removes a node info from the database
+func (ns *NodeStateMachine) deleteNode(id enode.ID) {
+	ns.db.Delete(append(ns.dbNodeKey, id[:]...))
+}
+
+// saveToDb saves all nodes that have been changed but not saved immediately
+func (ns *NodeStateMachine) saveToDb() {
+	ns.persistClock()
+	for id, node := range ns.nodes {
+		if node.dirty {
+			err := ns.saveNode(id, node)
+			if err != nil {
+				log.Error("Failed to save node", "id", id, "error", err)
+			}
+		}
+	}
+}
+
+// UpdateState updates the given node state flags and processes all resulting callbacks.
+// It only returns after all subsequent immediate changes (including those changed by the
+// callbacks) have been processed.
+func (ns *NodeStateMachine) UpdateState(id enode.ID, set, reset NodeStateBitMask, timeout time.Duration) {
+	ns.lock.Lock()
+	ns.checkStarted()
+	if ns.stopped {
+		ns.lock.Unlock()
+		return
+	}
+	cb := ns.updateState(id, set, reset, timeout)
+	ns.lock.Unlock()
+	if cb != nil {
+		cb()
+	}
+}
+
+// updateState performs a node state update and returns a function that processes state
+// subscription callbacks and should be called while the mutex is not held.
+// If the timeout is specified, it means the set states will be reset after the specified
+// time interval.
+func (ns *NodeStateMachine) updateState(id enode.ID, set, reset NodeStateBitMask, timeout time.Duration) func() {
+	node := ns.nodes[id]
+	if node == nil {
+		node = ns.newNode()
+		ns.nodes[id] = node
+	}
+	newState := (node.state & (^reset)) | set
+	if newState == node.state {
+		return nil
+	}
+	oldState := node.state
+	changed := oldState ^ newState
+	node.state = newState
+
+	ns.removeTimeouts(node, oldState&(^newState))
+	setStates := newState & (^oldState)
+	if timeout != 0 && setStates != 0 {
+		ns.addTimeout(id, setStates, timeout)
+	}
+	if newState == 0 {
+		delete(ns.nodes, id)
+		if node.db {
+			ns.deleteNode(id)
+		}
+	} else {
+		if changed&ns.saveImmediately != 0 {
+			err := ns.saveNode(id, node)
+			if err != nil {
+				log.Error("Failed to save node", "id", id, "error", err)
+			}
+		} else if changed&ns.saveAtShutdown != 0 {
+			node.dirty = true
+		}
+		node.fieldGcCounter++
+	}
+	return func() {
+		// call state update subscription callbacks without holding the mutex
+		for _, sub := range ns.stateSubs {
+			if changed&sub.mask != 0 {
+				sub.callback(id, oldState&sub.mask, newState&sub.mask)
+			}
+		}
+		if newState != 0 {
+			ns.lock.Lock()
+			node.fieldGcCounter--
+			if node.fieldGcCounter == 0 {
+				// remove all fields that are not needed any more after reaching the final state
+				for i, f := range node.fields {
+					if f != nil {
+						if ns.nodeFieldMasks[i]&node.state == 0 {
+							node.fields[i] = nil
+						}
+					}
+				}
+			}
+			ns.lock.Unlock()
+		}
+	}
+}
+
+// offlineCallbacks calls state update callbacks at startup or shutdown
+func (ns *NodeStateMachine) offlineCallbacks(start bool) {
+	for _, cb := range ns.offlineCallbackList {
+		for _, sub := range ns.stateSubs {
+			offState := OfflineState & sub.mask
+			onState := cb.state & sub.mask
+			if offState != onState {
+				if start {
+					sub.callback(cb.id, offState, onState)
+				} else {
+					sub.callback(cb.id, onState, offState)
+				}
+			}
+		}
+	}
+	ns.offlineCallbackList = nil
+}
+
+// AddTimeout adds a node state timeout associated to the given state flag(s).
+// After the specified time interval, the relevant states will be reset.
+func (ns *NodeStateMachine) AddTimeout(id enode.ID, mask NodeStateBitMask, timeout time.Duration) {
+	ns.lock.Lock()
+	defer ns.lock.Unlock()
+
+	ns.checkStarted()
+	if ns.stopped {
+		return
+	}
+	ns.addTimeout(id, mask, timeout)
+}
+
+// addTimeout adds a node state timeout associated to the given state flag(s).
+func (ns *NodeStateMachine) addTimeout(id enode.ID, mask NodeStateBitMask, timeout time.Duration) {
+	node := ns.nodes[id]
+	if node == nil {
+		return
+	}
+	mask &= node.state
+	if mask == 0 {
+		return
+	}
+	ns.removeTimeouts(node, mask)
+	t := &nodeStateTimeout{
+		id:   id,
+		at:   ns.clock.Now() + mclock.AbsTime(timeout),
+		mask: mask,
+	}
+	t.timer = ns.clock.AfterFunc(timeout, func() {
+		ns.lock.Lock()
+		cb := ns.updateState(id, 0, t.mask, 0)
+		ns.lock.Unlock()
+		if cb != nil {
+			cb()
+		}
+	})
+	node.timeouts = append(node.timeouts, t)
+	if mask&ns.saveAtShutdown != 0 {
+		node.dirty = true
+	}
+}
+
+// removeTimeout removes node state timeouts associated to the given state flag(s).
+// If a timeout was associated to multiple flags which are not all included in the
+// specified remove mask then only the included flags are de-associated and the timer
+// stays active.
+func (ns *NodeStateMachine) removeTimeouts(node *nodeInfo, mask NodeStateBitMask) {
+	for i := 0; i < len(node.timeouts); i++ {
+		t := node.timeouts[i]
+		match := t.mask & mask
+		if match == 0 {
+			continue
+		}
+		t.mask -= match
+		if t.mask != 0 {
+			continue
+		}
+		t.timer.Stop()
+		node.timeouts[i] = node.timeouts[len(node.timeouts)-1]
+		node.timeouts = node.timeouts[:len(node.timeouts)-1]
+		i--
+	}
+}
+
+// RegisterField adds the node field if it has not been added before and returns the field index.
+// Node fields should be mapped before loading the node database or making the first state update.
+func (ns *NodeStateMachine) RegisterField(field *NodeStateField) (int, error) {
+	mask := ns.StatesMask(field.flags)
+	ns.lock.Lock()
+	defer ns.lock.Unlock()
+
+	// Short circuit if it's already registered.
+	if index, ok := ns.nodeFieldMap[field]; ok {
+		return index, nil
+	}
+	// Ensure the registration time window is still opened.
+	if ns.started {
+		return 0, errAlreadyStarted
+	}
+	// Ensure the field name is still available.
+	if _, ok := ns.nodeFieldNameMap[field.name]; ok {
+		return 0, errNameCollision
+	}
+	index := len(ns.nodeFields)
+	ns.nodeFields = append(ns.nodeFields, field)
+	ns.nodeFieldMasks = append(ns.nodeFieldMasks, mask)
+	ns.nodeFieldMap[field] = index
+	ns.nodeFieldNameMap[field.name] = index
+	return index, nil
+}
+
+// MustRegisterField calls RegisterField and panics if an error was returned.
+func (ns *NodeStateMachine) MustRegisterField(field *NodeStateField) int {
+	i, err := ns.RegisterField(field)
+	if err != nil {
+		panic(err)
+	}
+	return i
+}
+
+// GetField retrieves the given field of the given node
+func (ns *NodeStateMachine) GetField(id enode.ID, fieldId int) interface{} {
+	ns.lock.Lock()
+	defer ns.lock.Unlock()
+
+	ns.checkStarted()
+	if ns.stopped {
+		return nil
+	}
+	if node := ns.nodes[id]; node != nil && fieldId < len(node.fields) {
+		return node.fields[fieldId]
+	}
+	return nil
+}
+
+// SetField sets the given field of the given node
+func (ns *NodeStateMachine) SetField(id enode.ID, fieldId int, value interface{}) error {
+	ns.lock.Lock()
+	defer ns.lock.Unlock()
+
+	ns.checkStarted()
+	if ns.stopped {
+		return nil
+	}
+	// Allocate the node if it's non-existent
+	node := ns.nodes[id]
+	if node == nil {
+		node = ns.newNode()
+	}
+	// Refuse to set field if it's unknown or the relevant state is unset.
+	if fieldId >= len(ns.nodeFields) {
+		log.Error("Field index out of bounds", "index", fieldId, "field count", len(ns.nodeFields))
+		return errOutOfBound
+	}
+	if reflect.TypeOf(value) != ns.nodeFields[fieldId].ftype {
+		log.Error("Invalid field type", "type", reflect.TypeOf(value), "required", ns.nodeFields[fieldId].ftype)
+		return errInvalidField
+	}
+	fieldMask := ns.nodeFieldMasks[fieldId]
+	if fieldMask&node.state == 0 {
+		return nil
+	}
+	node.fields[fieldId] = value
+	ns.nodes[id] = node
+
+	// Persist node after change if necessary
+	if fieldMask&ns.saveImmediately != 0 {
+		err := ns.saveNode(id, node)
+		if err != nil {
+			log.Error("Failed to save node", "id", id, "error", err)
+		}
+	} else if fieldMask&ns.saveAtShutdown != 0 {
+		node.dirty = true
+	}
+	return nil
+}
+
+// RegisterState assigns a bit index to the given flag if it has not been mapped
+// before and returns the node state bit mask. State flags should be mapped before
+// loading the node database or making the first state update.
+func (ns *NodeStateMachine) RegisterState(flag *NodeStateFlag) (NodeStateBitMask, error) {
+	ns.lock.Lock()
+	defer ns.lock.Unlock()
+
+	// Short circuit if it's already registered.
+	if state, ok := ns.nodeStates[flag]; ok {
+		return NodeStateBitMask(1) << state, nil
+	}
+	// Ensure the registration time window is still opened.
+	if ns.started {
+		return NodeStateBitMask(0), errAlreadyStarted
+	}
+	// Ensure the registered states is under the limitation.
+	if len(ns.nodeStates) >= ns.stateLimit {
+		return NodeStateBitMask(0), errStateOverflow
+	}
+	// Ensure the flag name is still available.
+	if _, ok := ns.nodeStateNameMap[flag.name]; ok {
+		return NodeStateBitMask(0), errNameCollision
+	}
+	// Pass all checking, register it now
+	index := ns.stateCount
+	mask := NodeStateBitMask(1) << index
+	ns.stateCount++
+	ns.nodeStates[flag] = index
+	ns.nodeStateNameMap[flag.name] = index
+
+	if flag.saveImmediately {
+		ns.saveImmediately |= mask
+	}
+	if flag.saveAtShutdown {
+		ns.saveAtShutdown |= mask
+	}
+	return mask, nil
+}
+
+// MustRegisterState calls RegisterState and panics if an error was returned.
+func (ns *NodeStateMachine) MustRegisterState(flag *NodeStateFlag) NodeStateBitMask {
+	mask, err := ns.RegisterState(flag)
+	if err != nil {
+		panic(err)
+	}
+	return mask
+}
+
+// StateMask returns the state mask associated with given flag.
+func (ns *NodeStateMachine) StateMask(flag *NodeStateFlag) NodeStateBitMask {
+	ns.lock.Lock()
+	defer ns.lock.Unlock()
+
+	if state, ok := ns.nodeStates[flag]; ok {
+		return NodeStateBitMask(1) << state
+	}
+	log.Error("Unknown state flag", "name", flag.name)
+	return NodeStateBitMask(0)
+}
+
+// StatesMask assigns a bit index to the given flags if they have not been mapped before and
+// returns the node state bit mask.
+// State flags should be mapped before loading the node database or making the first state update.
+func (ns *NodeStateMachine) StatesMask(flags []*NodeStateFlag) NodeStateBitMask {
+	var mask NodeStateBitMask
+	for _, flag := range flags {
+		mask |= ns.StateMask(flag)
+	}
+	return mask
+}
+
+// stateToString returns a list of the names of the flags specified in the bit mask
+func (ns *NodeStateMachine) stateToString(states NodeStateBitMask) string {
+	s := "["
+	comma := false
+	for field, index := range ns.nodeStates {
+		if states&(NodeStateBitMask(1)<<index) != 0 {
+			if comma {
+				s = s + ", "
+			}
+			s = s + field.name
+			comma = true
+		}
+	}
+	s = s + "]"
+	return s
+}
+
+// String returns the 2-based format to better represent "bits"
+func (mask NodeStateBitMask) String() string {
+	return fmt.Sprintf("%b", mask)
+}

--- a/les/utils/nodestate_test.go
+++ b/les/utils/nodestate_test.go
@@ -1,0 +1,448 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+func indexToMask(index int) NodeStateBitMask {
+	return NodeStateBitMask(1) << index
+}
+
+func registerTestFlags(ns *NodeStateMachine, n int) []*NodeStateFlag {
+	var flags []*NodeStateFlag
+	for i := 0; i < n; i++ {
+		flag := NewNodeStateFlag(fmt.Sprintf("flag-%d", i), false, true)
+		flags = append(flags, flag)
+		ns.RegisterState(flag)
+	}
+	return flags
+}
+
+func registerTestFields(ns *NodeStateMachine, n int, flags []*NodeStateFlag) []*NodeStateField {
+	var fields []*NodeStateField
+	for i := 0; i < n; i++ {
+		f := flags[rand.Intn(len(flags))]
+		field := NewNodeStateField(fmt.Sprintf("field-%d", i), reflect.TypeOf(enr.Record{}), []*NodeStateFlag{f}, nil, nil)
+		fields = append(fields, field)
+		ns.RegisterField(field)
+	}
+	return fields
+}
+
+func TestCallback(t *testing.T) {
+	mdb, clock := rawdb.NewMemoryDatabase(), &mclock.Simulated{}
+	ns := NewNodeStateMachine(mdb, []byte("-ns"), clock)
+
+	// Register order flag 0-2
+	f0, _ := ns.RegisterState(NewNodeStateFlag("flag0", true, true))
+	f1, _ := ns.RegisterState(NewNodeStateFlag("flag1", true, true))
+	f2, _ := ns.RegisterState(NewNodeStateFlag("flag2", true, true))
+
+	set0 := make(chan struct{}, 1)
+	set1 := make(chan struct{}, 1)
+	set2 := make(chan struct{}, 1)
+	ns.AddStateSub(f0, func(id enode.ID, oldState, newState NodeStateBitMask) { set0 <- struct{}{} })
+	ns.AddStateSub(f1, func(id enode.ID, oldState, newState NodeStateBitMask) { set1 <- struct{}{} })
+	ns.AddStateSub(f2, func(id enode.ID, oldState, newState NodeStateBitMask) { set2 <- struct{}{} })
+
+	ns.Start()
+
+	ns.UpdateState(enode.ID{0x01}, f0, 0, 0)
+	ns.UpdateState(enode.ID{0x01}, f1, 0, time.Second)
+	ns.UpdateState(enode.ID{0x01}, f2, 0, 2*time.Second)
+
+	for i := 0; i < 3; i++ {
+		select {
+		case <-set0:
+		case <-set1:
+		case <-set2:
+		case <-time.After(time.Second):
+			t.Fatalf("failed to invoke callback")
+		}
+	}
+}
+
+func TestSaveImmediately(t *testing.T) {
+	mdb, clock := rawdb.NewMemoryDatabase(), &mclock.Simulated{}
+	ns := NewNodeStateMachine(mdb, []byte("-ns"), clock)
+
+	saveNode := make(chan *nodeInfo, 1)
+	ns.saveNodeHook = func(node *nodeInfo) {
+		saveNode <- node
+	}
+	// Register order flag 0-2
+	flag0 := NewNodeStateFlag("flag0", true, true)
+	flag1 := NewNodeStateFlag("flag1", true, true)
+	flag2 := NewNodeStateFlag("flag2", true, true)
+	f0, _ := ns.RegisterState(flag0)
+	f1, _ := ns.RegisterState(flag1)
+	f2, _ := ns.RegisterState(flag2)
+	fd, _ := ns.RegisterField(NewNodeStateField("field", reflect.TypeOf(""), []*NodeStateFlag{flag0, flag1, flag2}, nil, nil))
+
+	ns.Start()
+
+	check := func(expectStatus NodeStateBitMask, expectFields []interface{}) {
+		var node *nodeInfo
+		select {
+		case node = <-saveNode:
+		case <-time.After(time.Second):
+			t.Fatalf("Timeout")
+		}
+		if node == nil {
+			t.Fatalf("Empty node")
+		}
+		if node.state != expectStatus {
+			t.Fatalf("Status mismatch, want %v, got %v", node.state, expectStatus)
+		}
+		if !reflect.DeepEqual(node.fields, expectFields) {
+			t.Fatalf("Field mismatch, want %v, got %v", expectFields, node.fields)
+		}
+	}
+	// Set status
+	ns.UpdateState(enode.ID{0x01}, f0, 0, 0)
+	check(f0, []interface{}{nil})
+	ns.UpdateState(enode.ID{0x01}, f1, 0, 0)
+	check(f0|f1, []interface{}{nil})
+
+	// Set fields
+	ns.SetField(enode.ID{0x01}, fd, "hello world")
+	check(f0|f1, []interface{}{"hello world"})
+
+	ns.UpdateState(enode.ID{0x01}, f2, 0, 0)
+	check(f0|f1|f2, []interface{}{"hello world"})
+}
+
+func TestSaveAtShutdown(t *testing.T) {
+	mdb, clock := rawdb.NewMemoryDatabase(), &mclock.Simulated{}
+	ns := NewNodeStateMachine(mdb, []byte("-ns"), clock)
+
+	saveNode := make(chan *nodeInfo, 2)
+	ns.saveNodeHook = func(node *nodeInfo) {
+		saveNode <- node
+	}
+	// Register order flag 0-2
+	f0, _ := ns.RegisterState(NewNodeStateFlag("flag0", false, true))
+	f1, _ := ns.RegisterState(NewNodeStateFlag("flag1", false, true))
+	f2, _ := ns.RegisterState(NewNodeStateFlag("flag2", false, false)) // flag2 shouldn't be saved
+
+	ns.Start()
+
+	ns.UpdateState(enode.ID{0x01}, f0, 0, time.Second)
+	ns.UpdateState(enode.ID{0x02}, f1, 0, time.Second)
+	ns.UpdateState(enode.ID{0x03}, f2, 0, time.Second)
+	ns.Stop()
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-saveNode:
+		case <-time.After(time.Second):
+			t.Fatalf("Timeout")
+		}
+	}
+}
+
+func TestRegistrationProtection(t *testing.T) {
+	mdb, clock := rawdb.NewMemoryDatabase(), &mclock.Simulated{}
+	ns := NewNodeStateMachine(mdb, []byte("-ns"), clock)
+	flags := registerTestFlags(ns, 60)
+	fields := registerTestFields(ns, 30, flags)
+
+	// Before initialization, register flags
+	var cases = []struct {
+		flag      *NodeStateFlag
+		mask      NodeStateBitMask
+		expectErr error
+	}{
+		{flags[0], indexToMask(1), nil},
+		{flags[59], indexToMask(60), nil},
+		{NewNodeStateFlag("flag-0", false, true), 0, errNameCollision},
+		{NewNodeStateFlag("flag-59", false, true), 0, errNameCollision},
+		{NewNodeStateFlag("flag-60", false, true), indexToMask(61), nil},
+	}
+	for id, c := range cases {
+		mask, err := ns.RegisterState(c.flag)
+		if c.expectErr != nil {
+			if err == nil {
+				t.Fatalf("Expect error => case (%d) %v", id, c.expectErr)
+			}
+			if err != c.expectErr {
+				t.Fatalf("Error mismatch => case (%d), want %v, got %v", id, c.expectErr, err)
+			}
+			continue
+		}
+		if mask != c.mask {
+			t.Fatalf("Mask mismatch => case (%d), want %v, got %v", id, c.mask, mask)
+		}
+	}
+	// Before initialization, register fields
+	var cases2 = []struct {
+		field     *NodeStateField
+		fieldId   int
+		expectErr error
+	}{
+		{fields[0], 0, nil},
+		{fields[29], 29, nil},
+		{NewNodeStateField("field-0", reflect.TypeOf(enr.Record{}), nil, nil, nil), 0, errNameCollision},
+		{NewNodeStateField("field-29", reflect.TypeOf(enr.Record{}), nil, nil, nil), 0, errNameCollision},
+		{NewNodeStateField("field-30", reflect.TypeOf(enr.Record{}), nil, nil, nil), 30, nil},
+	}
+	for id, c := range cases2 {
+		index, err := ns.RegisterField(c.field)
+		if c.expectErr != nil {
+			if err == nil {
+				t.Fatalf("Expect error => case (%d) %v", id, c.expectErr)
+			}
+			if err != c.expectErr {
+				t.Fatalf("Error mismatch => case (%d), want %v, got %v", id, c.expectErr, err)
+			}
+			continue
+		}
+		if index != c.fieldId {
+			t.Fatalf("Field id mismatch => case (%d), want %v, got %v", id, c.fieldId, index)
+		}
+	}
+
+	ns.Start()
+
+	ns.UpdateState(enode.ID{0x1}, indexToMask(1), 0, 0)
+	_, err := ns.RegisterState(NewNodeStateFlag("flag-61", false, true))
+	if err != errAlreadyStarted {
+		t.Fatalf("Expect already init error")
+	}
+	_, err = ns.RegisterField(NewNodeStateField("field-31", reflect.TypeOf(enr.Record{}), nil, nil, nil))
+	if err != errAlreadyStarted {
+		t.Fatalf("Expect already init error")
+	}
+	err = ns.AddStateSub(indexToMask(1), nil)
+	if err != errAlreadyStarted {
+		t.Fatalf("Expect already init error")
+	}
+}
+
+func TestSetField(t *testing.T) {
+	mdb, clock := rawdb.NewMemoryDatabase(), &mclock.Simulated{}
+	ns := NewNodeStateMachine(mdb, []byte("-ns"), clock)
+
+	saveNode := make(chan *nodeInfo, 1)
+	ns.saveNodeHook = func(node *nodeInfo) {
+		saveNode <- node
+	}
+	flag := NewNodeStateFlag("flag", false, true)
+	f, _ := ns.RegisterState(flag)
+	fd, _ := ns.RegisterField(NewNodeStateField("field", reflect.TypeOf(""), []*NodeStateFlag{flag}, nil, nil))
+
+	ns.Start()
+
+	// Set field before setting state
+	ns.SetField(enode.ID{0x01}, fd, "hello world")
+	field := ns.GetField(enode.ID{0x01}, fd)
+	if field != nil {
+		t.Fatalf("Field shouldn't be set before setting states")
+	}
+	// Set field after setting state
+	ns.UpdateState(enode.ID{0x01}, f, 0, time.Second)
+	ns.SetField(enode.ID{0x01}, fd, "hello world")
+	field = ns.GetField(enode.ID{0x01}, fd)
+	if field == nil {
+		t.Fatalf("Field should be set after setting states")
+	}
+	if err := ns.SetField(enode.ID{0x01}, fd, 123); err != errInvalidField {
+		t.Fatalf("Invalid field should be rejected")
+	}
+	// Dirty node should be written back
+	ns.Stop()
+	select {
+	case <-saveNode:
+	case <-time.After(time.Second):
+		t.Fatalf("Timeout")
+	}
+}
+
+func TestUnsetField(t *testing.T) {
+	mdb, clock := rawdb.NewMemoryDatabase(), &mclock.Simulated{}
+	ns := NewNodeStateMachine(mdb, []byte("-ns"), clock)
+
+	flag := NewNodeStateFlag("flag", false, true)
+	f, _ := ns.RegisterState(flag)
+	fd, _ := ns.RegisterField(NewNodeStateField("field", reflect.TypeOf(""), []*NodeStateFlag{flag}, nil, nil))
+
+	ns.Start()
+
+	ns.UpdateState(enode.ID{0x01}, f, 0, time.Second)
+	ns.SetField(enode.ID{0x01}, fd, "hello world")
+
+	ns.UpdateState(enode.ID{0x01}, 0, f, 0)
+	if field := ns.GetField(enode.ID{0x01}, fd); field != nil {
+		t.Fatalf("Field should be unset")
+	}
+}
+
+func TestUpdateState(t *testing.T) {
+	mdb, clock := rawdb.NewMemoryDatabase(), &mclock.Simulated{}
+	ns := NewNodeStateMachine(mdb, []byte("-ns"), clock)
+
+	f0, _ := ns.RegisterState(NewNodeStateFlag("flag0", false, false))
+	f1, _ := ns.RegisterState(NewNodeStateFlag("flag1", false, false))
+	f2, _ := ns.RegisterState(NewNodeStateFlag("flag2", false, false))
+
+	type change struct{ old, new NodeStateBitMask }
+	set := make(chan change, 1)
+	ns.AddStateSub(f0|f1, func(id enode.ID, oldState, newState NodeStateBitMask) {
+		set <- change{
+			old: oldState,
+			new: newState,
+		}
+	})
+
+	ns.Start()
+
+	check := func(expectOld, expectNew NodeStateBitMask, expectChange bool) {
+		if expectChange {
+			select {
+			case c := <-set:
+				if c.old != expectOld {
+					t.Fatalf("Old state mismatch")
+				}
+				if c.new != expectNew {
+					t.Fatalf("New state mismatch")
+				}
+			case <-time.After(time.Second):
+			}
+			return
+		}
+		select {
+		case <-set:
+			t.Fatalf("Unexpected change")
+		case <-time.After(time.Millisecond * 100):
+			return
+		}
+	}
+	ns.UpdateState(enode.ID{0x01}, f0, 0, 0)
+	check(0, f0, true)
+
+	ns.UpdateState(enode.ID{0x01}, f1, 0, 0)
+	check(f0, f0|f1, true)
+
+	ns.UpdateState(enode.ID{0x01}, f2, 0, 0)
+	check(0, 0, false)
+
+	ns.UpdateState(enode.ID{0x01}, 0, f0, 0)
+	check(f0|f1, f1, true)
+
+	ns.UpdateState(enode.ID{0x01}, 0, f1, 0)
+	check(f1, 0, true)
+
+	ns.UpdateState(enode.ID{0x01}, 0, f2, 0)
+	check(0, 0, false)
+
+	ns.UpdateState(enode.ID{0x01}, f0|f1, 0, time.Second)
+	check(0, f0|f1, true)
+	clock.Run(time.Second)
+	check(f0|f1, 0, true)
+}
+
+func fd0enc(field interface{}) ([]byte, error) {
+	if u, ok := field.(uint64); ok {
+		enc, err := rlp.EncodeToBytes(&u)
+		return enc, err
+	} else {
+		return nil, errInvalidField
+	}
+}
+
+func fd0dec(enc []byte) (interface{}, error) {
+	var u uint64
+	err := rlp.DecodeBytes(enc, &u)
+	return u, err
+}
+
+func fd1enc(field interface{}) ([]byte, error) {
+	if s, ok := field.(string); ok {
+		return []byte(s), nil
+	} else {
+		return nil, errInvalidField
+	}
+}
+
+func fd1dec(enc []byte) (interface{}, error) {
+	return string(enc), nil
+}
+
+func TestPersistent(t *testing.T) {
+	mdb, clock := rawdb.NewMemoryDatabase(), &mclock.Simulated{}
+	ns := NewNodeStateMachine(mdb, []byte("-ns"), clock)
+
+	f0 := NewNodeStateFlag("flag0", false, true)
+	f1 := NewNodeStateFlag("flag1", false, true)
+	s0, _ := ns.RegisterState(f0)
+	s1, _ := ns.RegisterState(f1)
+	fd0, _ := ns.RegisterField(NewNodeStateField("field0", reflect.TypeOf(uint64(0)), []*NodeStateFlag{f0}, fd0enc, fd0dec))
+	fd1, _ := ns.RegisterField(NewNodeStateField("field1", reflect.TypeOf(""), []*NodeStateFlag{f1}, fd1enc, fd1dec))
+	ns.Start()
+	ns.UpdateState(enode.ID{0x01}, s0, 0, time.Second)
+	ns.UpdateState(enode.ID{0x01}, s1, 0, time.Second)
+	ns.SetField(enode.ID{0x01}, fd0, uint64(100))
+	ns.SetField(enode.ID{0x01}, fd1, "hello world")
+	ns.Stop()
+
+	ns2 := NewNodeStateMachine(mdb, []byte("-ns"), clock)
+	ns2.RegisterState(f0)
+	ns2.RegisterState(f1)
+	fd0, _ = ns2.RegisterField(NewNodeStateField("field0", reflect.TypeOf(uint64(0)), []*NodeStateFlag{f0}, fd0enc, fd0dec))
+	fd1, _ = ns2.RegisterField(NewNodeStateField("field1", reflect.TypeOf(""), []*NodeStateFlag{f1}, fd1enc, fd1dec))
+	ns2.Start()
+	field0 := ns2.GetField(enode.ID{0x01}, fd0)
+	if !reflect.DeepEqual(field0, uint64(100)) {
+		t.Fatalf("Field changed")
+	}
+	field1 := ns2.GetField(enode.ID{0x01}, fd1)
+	if !reflect.DeepEqual(field1, "hello world") {
+		t.Fatalf("Field changed")
+	}
+
+	ns3 := NewNodeStateMachine(mdb, []byte("-ns"), clock)
+	// Different order
+	ns3.RegisterState(f1)
+	ns3.RegisterState(f0)
+	fd1, _ = ns3.RegisterField(NewNodeStateField("field1", reflect.TypeOf(""), []*NodeStateFlag{f1}, fd1enc, fd1dec))
+	fd0, _ = ns3.RegisterField(NewNodeStateField("field0", reflect.TypeOf(uint64(0)), []*NodeStateFlag{f0}, fd0enc, fd0dec))
+	// additional registeration
+	ns3.RegisterState(NewNodeStateFlag("flag2", false, true))
+	ns3.RegisterField(NewNodeStateField("field2", reflect.TypeOf(uint32(0)), []*NodeStateFlag{f0}, nil, nil))
+
+	ns3.Start()
+	field0 = ns3.GetField(enode.ID{0x01}, fd0)
+	if !reflect.DeepEqual(field0, uint64(100)) {
+		t.Fatalf("Field changed")
+	}
+	field1 = ns3.GetField(enode.ID{0x01}, fd1)
+	if !reflect.DeepEqual(field1, "hello world") {
+		t.Fatalf("Field changed")
+	}
+}

--- a/les/utils/weighted_select_test.go
+++ b/les/utils/weighted_select_test.go
@@ -26,17 +26,18 @@ type testWrsItem struct {
 	widx *int
 }
 
-func (t *testWrsItem) Weight() int64 {
+func testWeight(i interface{}) uint64 {
+	t := i.(*testWrsItem)
 	w := *t.widx
 	if w == -1 || w == t.idx {
-		return int64(t.idx + 1)
+		return uint64(t.idx + 1)
 	}
 	return 0
 }
 
 func TestWeightedRandomSelect(t *testing.T) {
 	testFn := func(cnt int) {
-		s := NewWeightedRandomSelect()
+		s := NewWeightedRandomSelect(testWeight)
 		w := -1
 		list := make([]testWrsItem, cnt)
 		for i := range list {


### PR DESCRIPTION
This PR does the following changes:

* Remove the `saveAtShutdown` property of `sfRedialWait`, it's unnecessary
* Add a filter option for state subscription: nodeID. So that other components can subscribe to the target node
*  Filter "uninterested" subs before call "offline" callbacks.
* Add unit tests, comments, minor code reorg