### PR TITLE
les: simplify prenegfilter

### DIFF
--- a/les/lespay/client/prenegfilter.go
+++ b/les/lespay/client/prenegfilter.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common/mclock"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/nodestate"
 )
@@ -35,17 +34,14 @@ type PreNegFilter struct {
 	queryTimeout, canDialTimeout    time.Duration
 	input, canDialIter              enode.Iterator
 	query                           PreNegQuery
-	pending                         map[*enode.Node]func()
-	pendingQueries, needQueries     int
+	pending                         map[*enode.Node]struct{}
+	needQueries                     int
 	maxPendingQueries, canDialCount int
 	waitingForNext, closed          bool
-	testClock                       *mclock.Simulated
 }
 
 // PreNegQuery callback performs connection pre-negotiation.
-// Note: the result callback function should always be called, if it has not been called
-// before then cancel should call it.
-type PreNegQuery func(n *enode.Node, result func(canDial bool)) (start, cancel func())
+type PreNegQuery func(n *enode.Node, result func(canDial bool)) func()
 
 // NewPreNegFilter creates a new PreNegFilter. sfQueried is set for each queried node, sfCanDial
 // is set together with sfQueried being reset if the callback returned a positive answer. The output
@@ -55,9 +51,7 @@ type PreNegQuery func(n *enode.Node, result func(canDial bool)) (start, cancel f
 // with an active sfCanDial flag and the output iterator is already being read. Note that until
 // sfCanDial is reset or times out the filter won't start more queries even if the dial candidate
 // has been returned by the output iterator.
-// If a simulated clock is used for testing then it should be provided in order to advance
-// clock when waiting for query results.
-func NewPreNegFilter(ns *nodestate.NodeStateMachine, input enode.Iterator, query PreNegQuery, sfQueried, sfCanDial nodestate.Flags, maxPendingQueries int, queryTimeout, canDialTimeout time.Duration, testClock *mclock.Simulated) *PreNegFilter {
+func NewPreNegFilter(ns *nodestate.NodeStateMachine, input enode.Iterator, query PreNegQuery, sfQueried, sfCanDial nodestate.Flags, maxPendingQueries int, queryTimeout, canDialTimeout time.Duration) *PreNegFilter {
 	pf := &PreNegFilter{
 		ns:                ns,
 		input:             input,
@@ -68,39 +62,38 @@ func NewPreNegFilter(ns *nodestate.NodeStateMachine, input enode.Iterator, query
 		canDialTimeout:    canDialTimeout,
 		maxPendingQueries: maxPendingQueries,
 		canDialIter:       NewQueueIterator(ns, sfCanDial, nodestate.Flags{}, false),
-		pending:           make(map[*enode.Node]func()),
-		testClock:         testClock,
+		pending:           make(map[*enode.Node]struct{}),
 	}
 	pf.cond = sync.NewCond(&pf.lock)
 	ns.SubscribeState(sfQueried.Or(sfCanDial), func(n *enode.Node, oldState, newState nodestate.Flags) {
-		var cancel func()
 		pf.lock.Lock()
+		defer pf.lock.Unlock()
+
+		// Maintain the 'canDial' result counter
 		if oldState.HasAll(sfCanDial) {
 			pf.canDialCount--
 		}
 		if newState.HasAll(sfCanDial) {
 			pf.canDialCount++
 		}
-		pf.checkQuery()
+		// Query timeout, remove it from the pending set and spin up one more query.
 		if oldState.HasAll(sfQueried) && newState.HasNone(sfQueried.Or(sfCanDial)) {
-			// query timeout, call cancel function (the query result callback will remove it from the map)
-			cancel = pf.pending[n]
-		}
-		pf.lock.Unlock()
-		if cancel != nil {
-			cancel()
+			if _, exist := pf.pending[n]; exist {
+				delete(pf.pending, n)
+				pf.checkQuery()
+			}
 		}
 	})
 	go pf.readLoop()
 	return pf
 }
 
-// checkQuery checks whether we need more queries and signals readLoop if necessary
+// checkQuery checks whether we need more queries and signals readLoop if necessary.
 func (pf *PreNegFilter) checkQuery() {
 	if pf.waitingForNext && pf.canDialCount == 0 {
 		pf.needQueries = pf.maxPendingQueries
 	}
-	if pf.needQueries > pf.pendingQueries {
+	if pf.needQueries > len(pf.pending) {
 		pf.cond.Signal()
 	}
 }
@@ -109,21 +102,9 @@ func (pf *PreNegFilter) checkQuery() {
 func (pf *PreNegFilter) readLoop() {
 	for {
 		pf.lock.Lock()
-		if pf.testClock != nil {
-			for pf.pendingQueries == pf.maxPendingQueries {
-				// advance simulated clock until our queries are finished or timed out
-				pf.lock.Unlock()
-				pf.testClock.Run(time.Second)
-				pf.lock.Lock()
-				if pf.closed {
-					pf.lock.Unlock()
-					return
-				}
-			}
-		}
-		for pf.needQueries <= pf.pendingQueries {
-			// either no queries are needed or we have enough pending; wait until more
-			// are needed
+		for pf.needQueries <= len(pf.pending) {
+			// either no queries are needed or we have enough pending;
+			// wait until more are needed
 			pf.cond.Wait()
 			if pf.closed {
 				pf.lock.Unlock()
@@ -131,6 +112,7 @@ func (pf *PreNegFilter) readLoop() {
 			}
 		}
 		pf.lock.Unlock()
+
 		// fetch a node from the input that is not pending at the moment
 		var node *enode.Node
 		for {
@@ -139,6 +121,7 @@ func (pf *PreNegFilter) readLoop() {
 				return
 			}
 			node = pf.input.Node()
+
 			pf.lock.Lock()
 			_, pending := pf.pending[node]
 			pf.lock.Unlock()
@@ -148,27 +131,24 @@ func (pf *PreNegFilter) readLoop() {
 		}
 		// set sfQueried and start the query
 		pf.ns.SetState(node, pf.sfQueried, nodestate.Flags{}, pf.queryTimeout)
-		start, cancel := pf.query(node, func(canDial bool) {
+		start := pf.query(node, func(canDial bool) {
 			if canDial {
 				pf.lock.Lock()
-				pf.needQueries = 0
-				pf.pendingQueries--
 				delete(pf.pending, node)
+				pf.needQueries = 0
 				pf.lock.Unlock()
 				pf.ns.SetState(node, pf.sfCanDial, pf.sfQueried, pf.canDialTimeout)
 			} else {
-				pf.ns.SetState(node, nodestate.Flags{}, pf.sfQueried, 0)
 				pf.lock.Lock()
-				pf.pendingQueries--
 				delete(pf.pending, node)
 				pf.checkQuery()
 				pf.lock.Unlock()
+				pf.ns.SetState(node, nodestate.Flags{}, pf.sfQueried, 0)
 			}
 		})
 		// add pending entry before actually starting
 		pf.lock.Lock()
-		pf.pendingQueries++
-		pf.pending[node] = cancel
+		pf.pending[node] = struct{}{}
 		pf.lock.Unlock()
 		start()
 	}
@@ -177,11 +157,10 @@ func (pf *PreNegFilter) readLoop() {
 // Next moves to the next selectable node.
 func (pf *PreNegFilter) Next() bool {
 	pf.lock.Lock()
-	pf.waitingForNext = true
-	// start queries if we cannot give a result immediately
+	pf.waitingForNext = true // start queries if we cannot give a result immediately
 	pf.checkQuery()
 	pf.lock.Unlock()
-	// get a result from the LIFO queue that returns nodes with active sfCanDial
+
 	next := pf.canDialIter.Next()
 	pf.lock.Lock()
 	pf.needQueries = 0

--- a/les/lespay/client/prenegfilter_test.go
+++ b/les/lespay/client/prenegfilter_test.go
@@ -63,20 +63,20 @@ func TestPreNegFilter(t *testing.T) {
 	}
 
 	var timeout uint32
-	testQuery := func(node *enode.Node, result func(canDial bool)) func() {
+	testQuery := func(node *enode.Node, result func(canDial bool)) (func(), func()) {
 		idx := testNodeIndex(node.ID())
 		switch queryResult[idx] {
 		case 0:
-			return func() { result(false) } // negative answer
+			return func() { result(false) }, func() {} // negative answer
 		case 1:
-			return func() { result(true) } // positive answer
+			return func() { result(true) }, func() {} // positive answer
 		case 2:
 			return func() {
 				clock.Run(5 * time.Second)
 				atomic.AddUint32(&timeout, 1)
-			} // timeout
+			}, func() {} // timeout
 		}
-		return nil
+		return nil, nil
 	}
 	pf := NewPreNegFilter(ns, enode.IterNodes(nodes), testQuery, sfTest1, sfTest2, 5, time.Second*5, time.Second*10)
 	pfr := enode.Filter(pf, func(node *enode.Node) bool {

--- a/les/serverpool.go
+++ b/les/serverpool.go
@@ -157,11 +157,7 @@ func newServerPool(db ethdb.KeyValueStore, dbKey []byte, vt *lpc.ValueTracker, d
 
 	iter := enode.Iterator(s.mixer)
 	if query != nil {
-		var testClock *mclock.Simulated
-		if testing {
-			testClock = mono.(*mclock.Simulated)
-		}
-		iter = lpc.NewPreNegFilter(s.ns, iter, query, sfQueried, sfCanDial, 5, time.Second*5, time.Second*10, testClock)
+		iter = lpc.NewPreNegFilter(s.ns, iter, query, sfQueried, sfCanDial, 5, time.Second*5, time.Second*10)
 	}
 	s.dialIterator = enode.Filter(iter, func(node *enode.Node) bool {
 		s.ns.SetState(node, sfDialed, sfCanDial, time.Second*10)


### PR DESCRIPTION
This PR does a few things:

* Remove the hacky simulation clock in the `prenegfilter`
* Maintain the `waiting` set by `prenegfilter` itself. 
   In the original implementation, we decrease the `canDialCounter` only when the tag is removed. 
   In another word, the **internal counter** depends on the **external** system. It's not a good idea to do it.
* Spin up enough queries if `needQueries` < `pending`.  In the original implementation, actually there is only one live query each time